### PR TITLE
fix(jitsi): resolve WebRTC media — no audio/video in rooms

### DIFF
--- a/clusters/cluster0/kubernetes/apps/jitsi/jitsi/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/jitsi/jitsi/app/helmrelease.yaml
@@ -158,6 +158,9 @@ spec:
           io.cilium/lb-ipam-ips: "192.168.2.9"
       useInternalStun: true
       publicIPs:
+        # WAN IP — external clients connect directly; requires UDM SE port forward UDP 10000 → 192.168.2.9:10000
+        - 87.92.48.51
+        # LAN service IP — used by Coturn as TURN relay peer to avoid hairpin NAT
         - 192.168.2.9
     coturn:
       enabled: true
@@ -177,8 +180,11 @@ spec:
         type: LoadBalancer
         annotations:
           io.cilium/lb-ipam-ips: "192.168.2.10"
+          # Registers turn.biggs.dog → 192.168.2.10 in k8s-gateway for internal DNS resolution
+          external-dns.alpha.kubernetes.io/hostname: "turn.biggs.dog"
       allowedPeerIPs:
-        - "10.244.0.0-10.244.255.255"
+        - "10.244.0.0-10.244.255.255" # pod CIDR
+        - "192.168.2.0-192.168.2.255" # service/LAN range — allows relay to JVB LB IP 192.168.2.9
       extraVolumes:
         - name: run
           emptyDir:

--- a/clusters/cluster0/kubernetes/apps/networking/k8s-gateway/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/k8s-gateway/app/helmrelease.yaml
@@ -26,11 +26,12 @@ spec:
   values:
     # nodeSelector:
     #   kubernetes.io/hostname: control-01
-    watchedResources: ["HTTPRoute"]
+    # Service added so k8s-gateway creates DNS for annotated LoadBalancer services (e.g. turn.biggs.dog → Coturn)
+    watchedResources: ["HTTPRoute", "Service"]
     domain: biggs.dog
     # fallthrough:
-      # enabled: true
-      # zones: [biggs.dog]
+    # enabled: true
+    # zones: [biggs.dog]
     dnsChallenge:
       enabled: true
       domain: dns01.clouddns.com
@@ -39,7 +40,7 @@ spec:
       type: LoadBalancer
       loadBalancerIP: 192.168.2.6
       port: 53
-      externalTrafficPolicy: Cluster  # Allow any node to forward traffic
+      externalTrafficPolicy: Cluster # Allow any node to forward traffic
       useTcp: true
     serviceAccount:
       create: true


### PR DESCRIPTION
## Problem

Users can join Jitsi rooms and authenticate successfully, but cannot hear or see each other. This is a WebRTC media path failure caused by four distinct issues.

---

## Root Causes & Fixes

### 1. JVB advertising only its private LAN IP in ICE candidates

**File:** 

 was set to  — a private LAN IP unreachable by external clients. JVB sends this IP as a WebRTC ICE candidate, so external clients could never establish a media path to it.

**Fix:** Added WAN IP  so external clients can reach JVB directly. Kept  (LAN service IP) as a second candidate so Coturn can relay to it without requiring hairpin NAT on the UDM SE.

> **Manual step required:** Add a UDM SE port forward: 

---

### 2. Coturn  blocking TURN relay to JVB

**File:** 

 only listed the pod CIDR . When Coturn acts as a TURN relay, the "peer" it connects to is JVB at its service IP  — which was blocked. All TURN-relayed media was silently dropped.

**Fix:** Added  to  to permit relay to the JVB LoadBalancer service IP.

---

### 3.  resolving to agentgateway internally (wrong host)

**Files:**  (Coturn service annotation) + 

The Cloudflare wildcard  means internal clients (whose DNS is forwarded by UDM SE to k8s-gateway) resolved  to the agentgateway, not Coturn. TURN connection attempts went to the wrong service.

**Fix:**
- Annotated the Coturn service with  so k8s-gateway creates the correct internal DNS entry .
- Added  to k8s-gateway  so it picks up LoadBalancer service annotations.

---

### 4.  has no external Cloudflare DNS record (TURN broken for WAN clients)

Cloudflare only has the wildcard  (proxied). TURN/TURNS uses raw UDP and custom TCP — **Cloudflare cannot proxy these protocols**. A separate, non-proxied DNS record is required.

> **Manual step required:** In Cloudflare DNS, add:
> - Type: 
> - Name: 
> - Value: 
> - Proxy: **DNS only (grey cloud)** ← critical, do NOT enable the orange cloud proxy

---

### 5. TURNS (port 5349) not port-forwarded

Coturn has  which starts a TLS TURN listener on port . This port has no WAN port forward configured.

> **Manual step required:** Add a UDM SE port forward:
> - 
> - 

---

## Summary of Manual Steps (not automatable in GitOps)

| Step | Where | Action |
|------|--------|--------|
| 1 | Cloudflare DNS | Add **DNS-only** A record:  |
| 2 | UDM SE | Port forward  (JVB direct media) |
| 3 | UDM SE | Port forward  (TURNS/TLS) |

The existing  port forward is correct and can remain as-is.