### PR TITLE
fix(jitsi): fix 15-disable-tls script — wrong shebang and wrong confi…

### DIFF
--- a/clusters/cluster0/kubernetes/apps/jitsi/jitsi/app/prosody-register-configmap.yaml
+++ b/clusters/cluster0/kubernetes/apps/jitsi/jitsi/app/prosody-register-configmap.yaml
@@ -1,33 +1,44 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: prosody-register-configmap
-    namespace: jitsi
+  name: prosody-register-configmap
+  namespace: jitsi
 data:
-    15-disable-tls: |
-        #!/bin/bash
-        # Disable c2s/s2s TLS requirement for internal cluster communication.
-        # The hardened Prosody image does not include openssl for cert generation.
-        CONFIG="/config/prosody.cfg.lua"
-        if [ -f "${CONFIG}" ]; then
-          sed -i 's/c2s_require_encryption\s*=\s*true/c2s_require_encryption = false/' "${CONFIG}"
-          sed -i 's/s2s_require_encryption\s*=\s*true/s2s_require_encryption = false/' "${CONFIG}"
+  15-disable-tls: |
+    #!/bin/sh
+    # Disable c2s/s2s TLS requirement for internal cluster communication.
+    # The hardened Prosody image does not include openssl for cert generation.
+    #
+    # FIX 1: shebang changed from #!/bin/bash — hardened images only ship /bin/sh.
+    # FIX 2: path changed to /run/prosody/config/ — with readOnlyRootFilesystem=true
+    #         the only writable location is the /run emptyDir, so the config is
+    #         generated there, not at /config/. The original path caused the
+    #         [ -f ] guard to silently exit without patching anything, leaving
+    #         Prosody with c2s_require_encryption=true and causing JVB's XMPP
+    #         connection to fail with a blank SSLHandshakeException.
+    for CONFIG in /run/prosody/config/prosody.cfg.lua /config/prosody.cfg.lua; do
+      if [ -f "${CONFIG}" ]; then
+        sed -i 's/c2s_require_encryption = true/c2s_require_encryption = false/g' "${CONFIG}"
+        sed -i 's/s2s_require_encryption = true/s2s_require_encryption = false/g' "${CONFIG}"
+        echo "[15-disable-tls] patched TLS settings in ${CONFIG}"
+        break
+      fi
+    done
+  75-register-custom-users: |
+    #!/command/with-contenv bash
+    # Register custom users from JITSI_USERS env var (format: user:password,user2:password2)
+    # This runs as an s6 oneshot after prosody is ready (after 70-register-setup)
+    PROSODY_CFG="/run/prosody/config/prosody.cfg.lua"
+    if [ -n "${JITSI_USERS}" ]; then
+      IFS=',' read -ra USERS <<< "${JITSI_USERS}"
+      for entry in "${USERS[@]}"; do
+        IFS=':' read -r username password <<< "${entry}"
+        if [ -n "${username}" ] && [ -n "${password}" ]; then
+          echo "[register-custom-users] Registering ${username}@${XMPP_DOMAIN:-meet.jitsi}"
+          prosodyctl --config "${PROSODY_CFG}" shell user create "${username}@${XMPP_DOMAIN:-meet.jitsi}" "${password}"
         fi
-    75-register-custom-users: |
-        #!/command/with-contenv bash
-        # Register custom users from JITSI_USERS env var (format: user:password,user2:password2)
-        # This runs as an s6 oneshot after prosody is ready (after 70-register-setup)
-        PROSODY_CFG="/run/prosody/config/prosody.cfg.lua"
-        if [ -n "${JITSI_USERS}" ]; then
-          IFS=',' read -ra USERS <<< "${JITSI_USERS}"
-          for entry in "${USERS[@]}"; do
-            IFS=':' read -r username password <<< "${entry}"
-            if [ -n "${username}" ] && [ -n "${password}" ]; then
-              echo "[register-custom-users] Registering ${username}@${XMPP_DOMAIN:-meet.jitsi}"
-              prosodyctl --config "${PROSODY_CFG}" shell user create "${username}@${XMPP_DOMAIN:-meet.jitsi}" "${password}"
-            fi
-          done
-        fi
-    oneshot-type: "oneshot"
-    oneshot-up: "/etc/s6-overlay/scripts/register-custom-users"
-    empty: ""
+      done
+    fi
+  oneshot-type: "oneshot"
+  oneshot-up: "/etc/s6-overlay/scripts/register-custom-users"
+  empty: ""


### PR DESCRIPTION
…g path

The script had two bugs that caused it to silently do nothing, leaving Prosody with c2s_require_encryption=true. JVB connects without TLS internally, so the XMPP handshake threw SSLHandshakeException (null message) logged as 'Error connecting: ' blank. With no JVB in the Prosody MUC, Jicofo has no bridge to route media through.

Bug 1 - Wrong shebang: #!/bin/bash
  Hardened images (jitsi-contrib) are minimal Alpine-derived containers
  that only ship /bin/sh. Bash is not present. The script failed before
  executing a single line.

Bug 2 - Wrong config path: /config/prosody.cfg.lua
  With readOnlyRootFilesystem=true the image cannot write to /config/
  (part of the read-only image layer). The runtime config is generated
  into the /run emptyDir at /run/prosody/config/prosody.cfg.lua — the
  same path already referenced correctly in 75-register-custom-users.
  The [ -f ] guard silently exited on every startup, never patching TLS.

Fix: shebang -> #!/bin/sh, loop over both paths (new path first, legacy path as fallback) so the script is robust against image variations.