### PR TITLE
fix(cilium): match ens/eno NICs for direct routing device

### DIFF
--- a/clusters/cluster0/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
       exclusive: true
     dashboards:
       enabled: true
-    devices: "eth+ enp+ enx+ bond+"
+    devices: "eth+ enp+ enx+ eno+ ens+ bond+"
     endpointRoutes:
       enabled: true
     envoy:


### PR DESCRIPTION
Add ens+ and eno+ to the Cilium devices pattern