### PR TITLE
Revert substrate/ateom 0.0.11 (restore kagent-default worker pool)

### DIFF
--- a/clusters/cluster1/flux-system/sources/substrate-crds-oci.yaml
+++ b/clusters/cluster1/flux-system/sources/substrate-crds-oci.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/kagent-dev/substrate/helm/substrate-crds
   ref:
-    tag: "0.0.11"
+    tag: "0.0.10"

--- a/clusters/cluster1/flux-system/sources/substrate-oci.yaml
+++ b/clusters/cluster1/flux-system/sources/substrate-oci.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/kagent-dev/substrate/helm/substrate
   ref:
-    tag: "0.0.11"
+    tag: "0.0.10"

--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
@@ -212,7 +212,7 @@ spec:
     substrateWorkerPool:
       create: true
       replicas: 1
-      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.11
+      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.10
       template:
         spec:
           nodeSelector:


### PR DESCRIPTION
## Problem

`kagent-default` worker pod in ai-system CrashLoops with:

```
atunnel: reading credential bundle: open /run/podidentity.podcert.ate.dev/credential-bundle.pem: no such file or directory
```

## Root cause

Renovate PRs #336/#337/#338 bumped substrate chart + CRDs + ateom-gvisor to 0.0.11, but the substrate HelmRelease upgrade **fails on immutable fields**:

- `Service/api`: chart 0.0.11 wants `clusterIP: None`; live svc has an allocated ClusterIP
- `Job/valkey-cluster-init`: template changed; Jobs are immutable

Result: version skew. atelet/atecontroller stuck at **v0.0.10**, while the kagent chart rolled the WorkerPool to **ateom-gvisor v0.0.11**, which requires the new podcert CSI identity bundle that only v0.0.11 infra provides.

Blocker for fixing forward: the forked `shrinedogg/ateapi` (`--client-jwt-jwks-url`) is only built on v0.0.10. Verified against upstream v0.0.11 source: it still does OIDC discovery against the issuer host (the unreachable Omni ULA), so the fork remains required and must be rebuilt on v0.0.11 before the upgrade can succeed. The helmrelease postRenderer warns this exact skew corrupts ateletpb RPCs.

## Fix

Revert all three bumps to 0.0.10. Flux will downgrade substrate/substrate-crds and roll the WorkerPool back to ateom v0.0.10, restoring the worker pool.

## Follow-up (separate PR)

1. Rebase the jwks-url patch onto substrate v0.0.11, build + push `shrinedogg/ateapi:v0.0.11-jwksurl`
2. Pin the new digest in the substrate postRenderer
3. Delete `svc/api` + `job/valkey-cluster-init` out-of-band so helm can recreate them with the new immutable shapes
4. Re-apply the 0.0.11 bumps