### PR TITLE
docs: normalize AGENTS.md style, remove em-dashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,33 @@
-# AGENTS.md — biggs.dog
+# AGENTS.md: biggs.dog
 
 Guidance for AI coding agents working in this repository. Tool-agnostic; the
 Zed-specific orchestration lives in `.rules` (which takes precedence in Zed).
 
 ## What this repo is
 
-Flux CD **GitOps** repo for a 2-cluster Kubernetes homelab. All desired cluster
+Flux CD GitOps repo for a 2-cluster Kubernetes homelab. All desired cluster
 state lives here as YAML; Flux reconciles it to the clusters. There is no app
-source code here — this is pure declarative infrastructure.
+source code here, only declarative infrastructure.
 
-- `clusters/cluster0/`, `clusters/cluster1/` — per-cluster state.
-  - `flux-system/` — Flux itself: `sources/` (GitRepository/HelmRepository/
+- `clusters/cluster0/`, `clusters/cluster1/`: per-cluster state.
+  - `flux-system/`: Flux itself, `sources/` (GitRepository/HelmRepository/
     OCIRepository) and `flux-operator/` (the FluxInstance).
-  - `kubernetes/apps/<namespace>/` — applications, grouped by namespace.
-- `docs/` — human notes. `.scripts/` — agent/MCP test + benchmark harnesses.
-- `.wip/` — scratch/in-progress debugging work (not reconciled).
+  - `kubernetes/apps/<namespace>/`: applications, grouped by namespace.
+- `docs/`: human notes. `.scripts/`: agent/MCP test + benchmark harnesses.
+- `.wip/`: scratch/in-progress debugging work (not reconciled).
 
 ## The golden rules (read before changing anything)
 
-1. **Edit YAML in Git; never mutate the cluster.** Use agents/kubectl to
-   *inspect* live state, but make every persistent change by editing files here
-   and letting Flux converge.
-2. **Flux tracks `main`.** Work on a feature branch if you like, but nothing
-   reconciles until merged to `main`. Don't promise a fix is "live" until then.
-3. **Secrets via External Secrets + 1Password.** Never hardcode credentials.
-   Add an `ExternalSecret` (ClusterSecretStore `onepassword-connect`) whose
+1. Edit YAML in Git; never mutate the cluster. Use agents/kubectl to
+   *inspect* live state, but make every persistent change by editing files
+   here and letting Flux converge.
+2. Flux tracks `main`. Work on a feature branch if you like, but nothing
+   reconciles until merged to `main`. Do not promise a fix is "live" until
+   then.
+3. Secrets via External Secrets + 1Password. Never hardcode credentials. Add
+   an `ExternalSecret` (ClusterSecretStore `onepassword-connect`) whose
    `remoteRef` `key`/`property` match the 1Password item + field labels
-   *exactly*. If an item doesn't exist yet, that's a prerequisite — say so.
+   *exactly*. If an item does not exist yet, that is a prerequisite: say so.
 
 ## App layout convention
 
@@ -43,7 +44,7 @@ kubernetes/apps/<ns>/<app>/
 - The `<ns>/kustomization.yaml` lists each app's `ks.yaml`; add new apps there.
 - Namespaces with Cilium default-deny (e.g. `ai-system`) need an explicit
   `CiliumNetworkPolicy` in `network-policies/policies/` for any new pod's
-  ingress/egress — a new app that talks to the network will silently fail
+  ingress/egress; a new app that talks to the network will silently fail
   without one.
 
 ## Validation
@@ -65,23 +66,27 @@ flux get sources all
 
 ## kagent agent routing (use the cluster's own agents)
 
-This cluster runs a **kagent MCP server** (`https://mcp.biggs.dog/mcp`,
-LAN/VPN only) exposing specialized agents. When a task matches a domain below,
-prefer `invoke_agent ai-system/<name>` over answering from memory. Call
-`list_agents` first — the invocable set changes mid-migration.
+This cluster runs a kagent MCP server (`https://mcp.biggs.dog/mcp`, LAN/VPN
+only) exposing specialized agents. When a task matches a domain below, prefer
+`invoke_agent ai-system/<name>` over answering from memory. Call
+`list_agents` first; the invocable set changes mid-migration.
 
-- ✅ `flux-agent` — Flux/GitOps inspection & reconciliation root-cause.
-- ✅ `vm-agent` — VictoriaMetrics: PromQL/MetricsQL, alerts, cardinality.
-- ✅ `exa-agent` — Web/code search, research (needs Exa API key).
-- ✅ `cilium-debug-agent` — Cilium connectivity/Hubble diagnostics; also
-  general cluster inspection (has `k8s_*` tools).
-- ✅ `cilium-policy-agent` — Author CiliumNetworkPolicies from intent.
-- ✅ `codebase-agent` — Structural code intelligence over indexed repos
-  (biggs.dog): find symbols, trace calls/data-flow, architecture, blast-radius.
-- ⚠️ `k8s-agent`, `helm-agent`, `promql-agent`, `observability-agent`,
-  `cilium-manager-agent` — Substrate SandboxAgents; READY but absent from MCP
-  `list_agents` (upstream kagent limitation). Use the ✅ fallbacks or
-  `kubectl`.
+Invocable now:
+
+- `flux-agent`: Flux/GitOps inspection and reconciliation root-cause.
+- `vm-agent`: VictoriaMetrics PromQL/MetricsQL, alerts, cardinality.
+- `exa-agent`: web/code search, research (needs Exa API key).
+- `cilium-debug-agent`: Cilium connectivity/Hubble diagnostics; also general
+  cluster inspection (has `k8s_*` tools).
+- `cilium-policy-agent`: authors CiliumNetworkPolicies from intent.
+- `codebase-agent`: structural code intelligence over indexed repos
+  (biggs.dog): find symbols, trace calls/data-flow, architecture,
+  blast-radius.
+
+READY but absent from MCP `list_agents` (Substrate SandboxAgents, upstream
+kagent limitation): `k8s-agent`, `helm-agent`, `promql-agent`,
+`observability-agent`, `cilium-manager-agent`. Use the invocable agents or
+`kubectl` as fallbacks.
 
 Read-only fallback for the MCP endpoint:
 `kubectl port-forward -n ai-system svc/kagent-controller 8083:8083`, then
@@ -94,6 +99,6 @@ Read-only fallback for the MCP endpoint:
 - ai-system pods pin to the GPU node via `nodeSelector:
   nvidia.com/gpu.present: "true"` and use `storageClassName: host-path` PVCs.
 - Containers run hardened: non-root, `allowPrivilegeEscalation: false`, drop
-  `ALL` capabilities, `seccompProfile: RuntimeDefault`, read-only root FS where
-  the image allows.
+  `ALL` capabilities, `seccompProfile: RuntimeDefault`, read-only root FS
+  where the image allows.
 - Keep `.rules` and this file in sync with the live agent set.


### PR DESCRIPTION
Rewrites AGENTS.md to match the normalized style used in biggs-sz and home-k8s-cluster: colon title, no em-dashes anywhere (commas/colons/parentheses instead), consistent section structure.

Content is preserved: golden rules, app layout convention, validation commands, kagent agent routing (emoji availability markers converted to plain-text groups), and repo conventions.