### PR TITLE
vllm: 224K context at gpu-mem 0.96 (max-margin exa profile)

### DIFF
--- a/clusters/cluster1/kubernetes/apps/ai-system/vllm/app/deployment.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/vllm/app/deployment.yaml
@@ -81,29 +81,26 @@ spec:
             # fp8 KV cache + hybrid attention keep the KV pool small even at
             # long context.
             - --kv-cache-dtype=fp8
-            # 192K context (raised from 131K). exa-agent's web searches return
-            # very large results (~38KB each); a multi-search session hit ~164K
-            # tokens of tool-result history and overflowed the old 131K cap
-            # (HTTP 400 input_tokens=131073). 192K gives ~28K margin over the
-            # largest observed exa session while staying safely under the fp8 KV
-            # pool (~243K-token capacity at util 0.95; ~6.4GiB for one 192K
-            # sequence vs ~8GiB pool). The model's native max is 262K, but the
-            # ~8GiB fp8 KV pool can't hold a full 262K sequence, so 262K would
-            # fail vLLM startup. To go higher, raise --gpu-memory-utilization
+            # 131K context. The fp8 KV cache + hybrid attention keep the KV pool
+            # small at this length. The model's native max is 262K, but the fp8
+            # KV pool can't hold a full 262K sequence, so 262K would fail vLLM
+            # startup. NOTE: a prior 192K setting was used to absorb very large
+            # exa-agent tool-result histories (a multi-search session once hit
+            # ~164K tokens and overflowed a 131K cap with HTTP 400
+            # input_tokens=131073); at 131K, watch for that overflow on heavy
+            # multi-search sessions. To go higher, raise --gpu-memory-utilization
             # (do NOT exceed ~0.96; 0.97 caused a full node lockup on 2026-06-25)
-            # or add VRAM. Raising max-model-len requires dropping max-num-seqs
-            # (longer sequences consume more KV) -- see below.
-            - --max-model-len=196608
+            # or add VRAM.
+            - --max-model-len=131072
             # nv-01's GPU is time-sliced (replicas=4) and shared with
             # GPU-operator validators and the DRA plugin. (The embeddings server
             # moved to CPU, so it no longer contends for VRAM here.) At 0.97 vLLM
             # reserved ~31.6GB, leaving ~1GB free, which contributed to a full
             # node lockup (2026-06-25) back when embeddings was ALSO on the GPU.
-            # With the lighter ~18GiB-resident NVFP4 quant, 0.95 (~30.4GB
-            # reserved, ~1.6GB free) yields ~8GiB fp8 KV -- ample for 131K plus
-            # concurrency. Could relax to 0.90 for more node headroom if KV ever
-            # proves over-provisioned; do NOT push past ~0.96.
-            - --gpu-memory-utilization=0.95
+            # With the lighter ~18GiB-resident NVFP4 quant, 0.92 leaves extra
+            # node headroom while still yielding an fp8 KV pool sufficient for
+            # the 131K window plus concurrency. Do NOT push past ~0.96.
+            - --gpu-memory-utilization=0.92
             # Per-step token budget for (chunked) prefill + decode. Bumped from
             # 4096 to 8192 to handle medium-length tool-context prompts more
             # efficiently, reducing the number of prefill steps. Short prompts
@@ -118,13 +115,14 @@ spec:
             # and the pod restarted (exit 0, "Completed"). 32-way still matches or
             # exceeds realistic concurrent agent count, lets vLLM QUEUE excess
             # requests instead of compute-locking, and keeps /health responsive.
-            # Keep capture-size == max-num-seqs. Dropped 32 -> 16 alongside the
-            # max-model-len raise (131K -> 192K): longer sequences consume more
-            # KV, so concurrency is halved to keep the ~8GiB fp8 KV pool from
-            # oversubscribing. 16-way still exceeds realistic concurrent agent
-            # count on this cluster.
-            - --max-num-seqs=16
-            - --max-cudagraph-capture-size=16
+            # Keep capture-size == max-num-seqs. Restored 16 -> 32 alongside the
+            # max-model-len revert (192K -> 131K): the earlier halving to 16 only
+            # existed to keep the ~8GiB fp8 KV pool from oversubscribing at 192K.
+            # Back at 131K, sequences are shorter and consume less KV, so 32-way
+            # fits comfortably and gives more headroom for concurrent agent
+            # fan-out.
+            - --max-num-seqs=32
+            - --max-cudagraph-capture-size=32
             - --enable-prefix-caching
             # Qwen3.6's hybrid (Gated-DeltaNet) arch may ship custom modeling
             # code; the model card sets trust-remote-code. NOTE: executes repo

--- a/clusters/cluster1/kubernetes/apps/ai-system/vllm/app/deployment.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/vllm/app/deployment.yaml
@@ -81,26 +81,31 @@ spec:
             # fp8 KV cache + hybrid attention keep the KV pool small even at
             # long context.
             - --kv-cache-dtype=fp8
-            # 131K context. The fp8 KV cache + hybrid attention keep the KV pool
-            # small at this length. The model's native max is 262K, but the fp8
-            # KV pool can't hold a full 262K sequence, so 262K would fail vLLM
-            # startup. NOTE: a prior 192K setting was used to absorb very large
-            # exa-agent tool-result histories (a multi-search session once hit
-            # ~164K tokens and overflowed a 131K cap with HTTP 400
-            # input_tokens=131073); at 131K, watch for that overflow on heavy
-            # multi-search sessions. To go higher, raise --gpu-memory-utilization
-            # (do NOT exceed ~0.96; 0.97 caused a full node lockup on 2026-06-25)
-            # or add VRAM.
-            - --max-model-len=131072
+            # 224K context. Sized to sit safely ABOVE the largest observed
+            # exa-agent tool-result history (~164K tokens; a multi-search
+            # session once overflowed a 131K cap with HTTP 400
+            # input_tokens=131073) with ~60K of headroom, and just BELOW the fp8
+            # KV pool's capacity so vLLM still boots. At util 0.96 the fp8 KV
+            # pool holds ~250K tokens (~8.3GiB); a 224K window leaves ~26K of
+            # slack under that cap. The model's native max is 262K, but the pool
+            # can't hold a full 262K sequence, so 262K would fail vLLM startup.
+            # Do NOT exceed ~0.96 util (0.97 caused a full node lockup on
+            # 2026-06-25). A single 224K sequence consumes ~7.4GiB of KV --
+            # nearly the whole pool -- so concurrency is capped low (see
+            # --max-num-seqs below); raising the window further requires more
+            # VRAM, not more util.
+            - --max-model-len=229376
             # nv-01's GPU is time-sliced (replicas=4) and shared with
             # GPU-operator validators and the DRA plugin. (The embeddings server
             # moved to CPU, so it no longer contends for VRAM here.) At 0.97 vLLM
             # reserved ~31.6GB, leaving ~1GB free, which contributed to a full
             # node lockup (2026-06-25) back when embeddings was ALSO on the GPU.
-            # With the lighter ~18GiB-resident NVFP4 quant, 0.92 leaves extra
-            # node headroom while still yielding an fp8 KV pool sufficient for
-            # the 131K window plus concurrency. Do NOT push past ~0.96.
-            - --gpu-memory-utilization=0.92
+            # With the lighter ~18GiB-resident NVFP4 quant, 0.96 (~30.7GB
+            # reserved) yields an ~8.3GiB fp8 KV pool (~250K tokens) -- the
+            # headroom needed to hold the 224K window above. This is the
+            # documented CEILING: 0.97 reserved ~31.6GB (~1GB free) and caused a
+            # full node lockup on 2026-06-25. Do NOT push past 0.96.
+            - --gpu-memory-utilization=0.96
             # Per-step token budget for (chunked) prefill + decode. Bumped from
             # 4096 to 8192 to handle medium-length tool-context prompts more
             # efficiently, reducing the number of prefill steps. Short prompts
@@ -115,14 +120,17 @@ spec:
             # and the pod restarted (exit 0, "Completed"). 32-way still matches or
             # exceeds realistic concurrent agent count, lets vLLM QUEUE excess
             # requests instead of compute-locking, and keeps /health responsive.
-            # Keep capture-size == max-num-seqs. Restored 16 -> 32 alongside the
-            # max-model-len revert (192K -> 131K): the earlier halving to 16 only
-            # existed to keep the ~8GiB fp8 KV pool from oversubscribing at 192K.
-            # Back at 131K, sequences are shorter and consume less KV, so 32-way
-            # fits comfortably and gives more headroom for concurrent agent
-            # fan-out.
-            - --max-num-seqs=32
-            - --max-cudagraph-capture-size=32
+            # Keep capture-size == max-num-seqs. Dropped 32 -> 8 alongside the
+            # max-model-len raise to 224K: a single 224K sequence consumes
+            # ~7.4GiB of the ~8.3GiB fp8 KV pool, so the pool can only hold a
+            # couple of full-length sequences at once. 8-way lets vLLM admit a
+            # burst of short/medium agent prompts while QUEUEING (not
+            # compute-locking) when several long-context sessions land together;
+            # prefix caching + chunked prefill keep queued work moving. If agent
+            # fan-out proves starved, the lever is more VRAM, not a higher
+            # max-num-seqs at this window.
+            - --max-num-seqs=8
+            - --max-cudagraph-capture-size=8
             - --enable-prefix-caching
             # Qwen3.6's hybrid (Gated-DeltaNet) arch may ship custom modeling
             # code; the model card sets trust-remote-code. NOTE: executes repo


### PR DESCRIPTION
## Summary

Set the vLLM Deployment engine args (`clusters/cluster1/kubernetes/apps/ai-system/vllm/app/deployment.yaml`) to the max-margin serving profile that eliminates exa-agent context overflow with wide headroom.

> Note: branch is named `vllm-131k-context-gpu092` from the first revision; the final profile is 224K / 0.96. Branch name is cosmetic.

| Arg | Original | This PR |
|---|---|---|
| `--max-model-len` | 196608 (192K) | **229376 (224K)** |
| `--gpu-memory-utilization` | 0.95 | **0.96** |
| `--kv-cache-dtype` | fp8 | fp8 (unchanged) |
| `--max-num-seqs` / `--max-cudagraph-capture-size` | 16 | **8** |

## Why these values
- **224K window** sits ~60K ABOVE the largest observed exa-agent tool-result history (~164K tokens; a multi-search session once overflowed a 131K cap with HTTP 400 `input_tokens=131073`), and just BELOW the fp8 KV pool capacity so vLLM still boots.
- **util 0.96** is the documented CEILING. 0.97 reserved ~31.6GB (~1GB free) and caused a full node lockup on 2026-06-25. Do NOT exceed 0.96. At 0.96 the fp8 KV pool is ~8.3GiB (~250K tokens), enough to hold the 224K window with ~26K slack.
- **Concurrency 8** is coupled DOWN because a single 224K sequence consumes ~7.4GiB of the ~8.3GiB pool. Only a few full-length sequences fit at once, so 8-way admits short/medium agent bursts and QUEUES long-context sessions rather than oversubscribing KV. The lever for more fan-out at this window is more VRAM, not a higher max-num-seqs.

Model native max is 262K, but the pool cannot hold a full 262K sequence, so 262K would fail startup. 224K is effectively the practical ceiling on this single-5090 node.

## Sizing caveat
KV-pool and per-sequence figures are estimates derived from the manifest's recorded measurements. The authoritative numbers are in the vLLM startup log (`GPU KV cache size: N tokens` / `Maximum concurrency for N tokens per request`). Confirm there after the pod cycles; if the pool comes in smaller than ~250K tokens, drop max-model-len toward ~208K.

## Deploy
Flux reconciles `ai-system/vllm` from `main` after merge. The Deployment uses `strategy: Recreate` and reloads VRAM on restart (weights on the PVC), so the new args take effect on the next pod cycle.