### PR TITLE
fix: pin ateom worker to v0.0.10 (podcert credential-bundle crashloop)

### DIFF
--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
@@ -212,7 +212,17 @@ spec:
     substrateWorkerPool:
       create: true
       replicas: 1
-      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.12
+      # PINNED to the substrate control-plane version. The ateom worker image
+      # MUST move in lockstep with ate-controller/atelet/atenet-router and the
+      # digest-pinned ateapi fork above (currently all v0.0.10). v0.0.12+
+      # workers hard-require an atunnel pod-identity credential bundle at
+      # /run/podidentity.podcert.ate.dev/credential-bundle.pem (PodCertificate
+      # projection, mtls mode); the v0.0.10 jwt-mode control plane never
+      # provisions it and Talos lacks the ClusterTrustBundle/PodCertificateRequest
+      # feature gates — the worker CrashLoops with "atunnel: reading credential
+      # bundle: ... no such file or directory". Renovate bumps for the whole
+      # substrate stack are grouped + automerge:false (see renovate.json).
+      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.10
       template:
         spec:
           nodeSelector:

--- a/renovate.json
+++ b/renovate.json
@@ -130,6 +130,20 @@
       ]
     },
     {
+      "description": "Substrate stack must upgrade in lockstep — never automerge",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/kagent-dev/substrate/ateom-gvisor",
+        "ghcr.io/kagent-dev/substrate/helm/substrate",
+        "ghcr.io/kagent-dev/substrate/helm/substrate-crds"
+      ],
+      "groupName": "substrate-stack",
+      "automerge": false,
+      "prBodyNotes": [
+        ":warning: The substrate stack upgrades only as a whole set: substrate + substrate-crds charts, the digest-pinned ateapi fork (apps/ai-system/substrate/app/helmrelease.yaml), and the ateom worker image (apps/ai-system/kagent/app/helmrelease.yaml). An ateom worker newer than the control plane CrashLoops with `atunnel: reading credential bundle: open /run/podidentity.podcert.ate.dev/credential-bundle.pem: no such file or directory` (worker mTLS needs PodCertificate projection; this cluster runs jwt mode and Talos lacks the feature gates). The 0.0.12 chart also fails server-side apply on a Role hardcoded to the `ate-system` namespace (substrate runs in ai-system here). Before merging: rebase the ateapi fork to the new version, work around the ate-system Role, add spec.pauseImage to apps/ai-system/substrate/app/sandboxconfig.yaml (required by 0.0.12 CRDs), and decide the worker pod-identity story."
+      ]
+    },
+    {
       "description": "Track floating tags by digest. Tags like latest/edge/main are not versions, so Renovate skips them as invalid-value; pinning the digest lets it raise update PRs when the tag is rebuilt. (nsyncd is also semver-tracked; the digest pin just adds rebuild-level updates.)",
       "matchDatasources": ["docker"],
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

`kagent-default` has been in CrashLoopBackOff (`0/1`, 24+ restarts) since Aug 13 with:

```
Error while executing: while configuring atunnel: atunnel: reading credential bundle:
open /run/podidentity.podcert.ate.dev/credential-bundle.pem: no such file or directory
```

The OTLP `127.0.0.1:4317` line in the same log is shutdown noise (metrics flush during the fatal exit), not a cause.

## Root cause: substrate version skew

- **Worker bumped, control plane didn't.** Renovate PR #349 (Aug 13) bumped only `ateom-gvisor` to v0.0.12. Binary forensics: v0.0.12 hard-requires the atunnel pod-identity credential bundle (worker mTLS: `Worker Pod credential bundle used by atunnel for inbound serving and outbound mTLS`); v0.0.10 has no such requirement (jwt mode).
- **The control plane can't follow.** The substrate HelmRelease has failed for 18d: every 0.0.12 chart upgrade dies at server-side apply on a Role hardcoded to the `ate-system` namespace (substrate runs in `ai-system` here), then rolls back to v39 (0.0.10).
- **Nothing provisions the file anyway.** The cluster runs `auth.mode: jwt`, and Talos lacks the `ClusterTrustBundle`/`PodCertificateRequest` feature gates needed for PodCertificate projection.
- **The Aug 13 CSI fix (fc73d9d3) half-landed.** `kagent-podcert-patch` was never added to the parent `ai-system/kustomization.yaml`, and it builds **zero resources** (`resources: []` + a patch targeting a Deployment that only exists at runtime, generated by the ate-controller from the `WorkerPool` CR). The `substrate-podcert-side` ClusterIssuer is also unreferenced by `csi-driver/kustomization.yaml`.

## Changes

1. `kagent/app/helmrelease.yaml` — pin `ateomImage` back to `v0.0.10` (lockstep with the control plane + digest-pinned ateapi fork), with a comment documenting why.
2. `renovate.json` — new `substrate-stack` group (ateom-gvisor + substrate charts) with `automerge: false` and PR notes listing the manual steps a real 0.0.12+ migration needs (ateapi fork rebase, ate-system Role workaround, `pauseImage` in Sandboxconfig, worker pod-identity story).

## Verification

- [x] `kubectl kustomize clusters/cluster1/kubernetes/apps/ai-system` renders clean (31 docs)
- [x] helmrelease values parse; `ateomImage = …ateom-gvisor:v0.0.10`
- [x] Binary diff v0.0.10 vs v0.0.12 ateom-gvisor confirms the requirement is new in v0.0.12
- [ ] Post-merge: Flux reconciles, `kagent-default` goes `1/1 Running`, no `atunnel` errors in logs