### PR TITLE
fix: unblock substrate Kustomization (pauseImage + pin chart source to 0.0.10)

### DIFF
--- a/clusters/cluster1/flux-system/sources/substrate-oci.yaml
+++ b/clusters/cluster1/flux-system/sources/substrate-oci.yaml
@@ -8,4 +8,10 @@ spec:
   interval: 1h
   url: oci://ghcr.io/kagent-dev/substrate/helm/substrate
   ref:
-    tag: "0.0.12"
+    # PINNED to 0.0.10 to match the deployed control plane (release v39) and
+    # the digest-pinned ateapi fork. The 0.0.12 chart cannot install here:
+    # server-side apply fails on a Role hardcoded to the `ate-system`
+    # namespace (substrate runs in ai-system on this cluster). Renovate bumps
+    # are grouped + automerge:false — see the substrate-stack rule in
+    # renovate.json for the full migration checklist.
+    tag: "0.0.10"

--- a/clusters/cluster1/kubernetes/apps/ai-system/substrate/app/sandboxconfig.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/substrate/app/sandboxconfig.yaml
@@ -37,6 +37,12 @@ metadata:
 spec:
   sandboxClass: gvisor
   default: true
+  # Required by the substrate 0.0.12 CRDs (and digest-pinned by CEL rule:
+  # changing the image invalidates actor snapshots). This is the exact image
+  # the live kagent-controller already passes in its substrate config, so
+  # existing snapshots stay restorable — do not "modernize" it to
+  # registry.k8s.io/pause without a snapshot-migration story.
+  pauseImage: gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da
   assets:
     amd64:
       runsc:


### PR DESCRIPTION
## Summary

The `substrate` Flux Kustomization has been `Ready=False` for **18 days**:

```
SandboxConfig/ai-system/gvisor-default dry-run failed (Invalid):
spec.pauseImage: Required value
```

## Root cause

Two chained problems, both fallout from the substrate version skew fixed in #375:

1. **Missing required field.** `substrate-crds` 0.0.12 (which deployed fine) makes `spec.pauseImage` required with a CEL rule forcing digest pinning (`self.contains('@')`). The repo SandboxConfig predates that CRD. Because the ks dry-run fails, the whole Kustomization — including its HelmRelease — never reconciles.
2. **Doomed upgrade loop.** The `substrate` HelmRelease kept retrying the 0.0.12 chart and dying at server-side apply on a Role hardcoded to the `ate-system` namespace (substrate runs in `ai-system` here), then rolling back to v39 (0.0.10). Desired state pointed at a chart that cannot install on this cluster.

## Changes

1. `substrate/app/sandboxconfig.yaml` — add `pauseImage` pinned to the exact image the live kagent-controller already passes (`gcr.io/gke-release/pause@sha256:bcbd57ba…65da`). Behavior-preserving: existing actor snapshots were created with this image; changing it would invalidate them (per the CRD's own CEL message).
2. `flux-system/sources/substrate-oci.yaml` — pin the chart source back to `0.0.10`. The deployed release **is** v39 (0.0.10) after the rollbacks; pinning the source makes desired == deployed so helm no-ops and the HelmRelease goes Ready. CRDs intentionally stay at 0.0.12 — they deployed cleanly, and newer-CRDs/older-control-plane is the safe ordering during skew.

## Verification

- [x] `kubectl kustomize clusters/cluster1/kubernetes/apps/ai-system` renders clean (31 docs)
- [x] `kubectl apply --dry-run=server` on the SandboxConfig passes live 0.0.12 CEL validation
- [x] rustfs `ate-snapshots/runsc` object confirmed present (the repo asset URL's target), 129 MB, staged 2026-06-30
- [ ] Post-merge: `flux get kustomization substrate` → Ready=True; HelmRelease substrate → Ready=True (no-op upgrade of v39); `kagent-default` still 1/1 Running

## Post-merge commands

```sh
flux reconcile source git flux-system -n flux-system
# confirm new revision, then:
flux reconcile kustomization substrate -n flux-system --with-source
```
