### PR TITLE
Revert "chore(deps): update ateom-gvisor docker tag to v0.0.12" (re-introduces crashloop)

### DIFF
--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
@@ -222,7 +222,7 @@ spec:
       # feature gates — the worker CrashLoops with "atunnel: reading credential
       # bundle: ... no such file or directory". Renovate bumps for the whole
       # substrate stack are grouped + automerge:false (see renovate.json).
-      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.12
+      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.10
       template:
         spec:
           nodeSelector:


### PR DESCRIPTION
Reverts shrinedogg/biggs.dog#376