### PR TITLE
feat: cluster0 workload changes for on-prem single-node Talos

### DIFF
--- a/clusters/cluster0/flux-system/flux-operator/app/flux-instance.yaml
+++ b/clusters/cluster0/flux-system/flux-operator/app/flux-instance.yaml
@@ -65,4 +65,4 @@ spec:
     ref: "refs/heads/main"
     path: "clusters/cluster0"
     provider: github
-    pullSecret: "flux-system"
+    pullSecret: "flux-github-pat"

--- a/clusters/cluster0/flux-system/sources/external-dns-repo.yaml
+++ b/clusters/cluster0/flux-system/sources/external-dns-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-dns
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://kubernetes-sigs.github.io/external-dns/

--- a/clusters/cluster0/flux-system/sources/flux-system-git.yaml
+++ b/clusters/cluster0/flux-system/sources/flux-system-git.yaml
@@ -9,4 +9,4 @@ spec:
   ref:
     branch: main
   secretRef:
-    name: flux-system
+    name: flux-github-pat

--- a/clusters/cluster0/flux-system/sources/kustomization.yaml
+++ b/clusters/cluster0/flux-system/sources/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - flux-operator-repo.yaml
   - cert-manager-repo.yaml
   - external-secrets-repo.yaml
+  - openebs-repo.yaml
+  - external-dns-repo.yaml
   - onepass-repo.yaml
   - cilium-repo.yaml
   - gateway-api-crds-git.yaml

--- a/clusters/cluster0/flux-system/sources/openebs-repo.yaml
+++ b/clusters/cluster0/flux-system/sources/openebs-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: openebs
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://openebs.github.io/openebs/

--- a/clusters/cluster0/kubernetes/apps/auth/dex/app/httproute.yaml
+++ b/clusters/cluster0/kubernetes/apps/auth/dex/app/httproute.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: auth
   labels:
     app.kubernetes.io/name: dex
+  annotations:
+    # external-dns CNAMEs this hostname to home.biggs.dog (ddns-maintained WAN IP)
+    external-dns.alpha.kubernetes.io/target: home.biggs.dog
 spec:
   hostnames:
     - dex.biggs.dog

--- a/clusters/cluster0/kubernetes/apps/netbird/netbird/app/httproute.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird/netbird/app/httproute.yaml
@@ -10,6 +10,9 @@ metadata:
   namespace: netbird
   labels:
     app.kubernetes.io/name: netbird
+  annotations:
+    # external-dns CNAMEs this hostname to home.biggs.dog (ddns-maintained WAN IP)
+    external-dns.alpha.kubernetes.io/target: home.biggs.dog
 spec:
   parentRefs:
     - name: cluster0-gateway

--- a/clusters/cluster0/kubernetes/apps/netbird/netbird/app/server-deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird/netbird/app/server-deployment.yaml
@@ -90,7 +90,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: upcloud-block-storage-maxiops
+  storageClassName: host-path
   resources:
     requests:
       storage: 1Gi

--- a/clusters/cluster0/kubernetes/apps/netbird/netbird/app/services.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird/netbird/app/services.yaml
@@ -45,18 +45,11 @@ spec:
 ---
 # STUN (UDP 3478) exposure.
 #
-# The UpCloud Managed Load Balancer (used by type: LoadBalancer via the UpCloud
-# CCM) only supports TCP/HTTP frontends -- there is NO UDP mode (product-level
-# limitation). So a LoadBalancer Service for UDP stays pending forever
-# (SyncLoadBalancerFailed, LB stuck at 'setup-server'). agentgateway likewise
-# can't route UDP. So STUN is exposed directly on the node's public IP instead.
-#
-# 87.58.147.51 is bound on the node's eth2 (verified), and the single node owns
-# it, so externalIPs makes Cilium (kube-proxy-replacement) serve UDP 3478 on the
-# node's public NIC -> the netbird-server pod. NetBird advertises STUN to
-# clients as stun:netbird.biggs.dog:3478 (auto-derived from exposedAddress); once
-# netbird.biggs.dog is DNS-only -> 87.58.147.51 and the UpCloud firewall allows
-# inbound UDP 3478, road-warrior clients reach STUN here. No cloud LB involved.
+# On-prem single-node cluster0 (2026-09 migration): UDP 3478 rides the node's
+# own IP 192.168.2.31 via Cilium LB-IPAM (sharing key cluster0-edge) -- the UpCloud Managed LB had no UDP mode, which forced
+# externalIPs; that workaround is gone. NetBird advertises STUN as
+# stun:netbird.biggs.dog:3478; netbird.biggs.dog CNAMEs to home.biggs.dog
+# (external-dns + ddns) and the UDM forwards UDP 3478 to the VIP.
 apiVersion: v1
 kind: Service
 metadata:
@@ -65,10 +58,11 @@ metadata:
   labels:
     app.kubernetes.io/name: netbird
     app.kubernetes.io/component: server
+  annotations:
+    lbipam.cilium.io/ips: 192.168.2.31
+    lbipam.cilium.io/sharing-key: cluster0-edge
 spec:
-  type: ClusterIP
-  externalIPs:
-    - 87.58.147.51 # node eth2 public IP (single-node cluster0)
+  type: LoadBalancer
   selector:
     app.kubernetes.io/name: netbird
     app.kubernetes.io/component: server

--- a/clusters/cluster0/kubernetes/apps/netbird/netbird/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/netbird/netbird/ks.yaml
@@ -17,6 +17,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
   dependsOn:
+    - name: openebs
     - name: secretstore
     - name: issuers
     - name: dex

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/capi.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/capi.yaml
@@ -1,0 +1,169 @@
+# Namespaces: capi-operator-system, capi-system, cabpt-system, cacppt-system,
+# capt-system (CAPI management plane; see clusters/cluster0/capi/).
+# Default-deny is implicit (empty endpointSelector allow policies).
+# Egress needed:
+#  - kube-apiserver (all controllers)
+#  - DNS (L7 proxy convention, see networking.yaml note)
+#  - world:443 (the CAPI operator downloads provider manifests from GitHub
+#    releases; cert-manager webhook is covered by the apiserver rule)
+#  - LAN 192.168.2.0/24:6443 (CAPT reaches the EXTERNAL Tinkerbell API on
+#    cluster1 while Tinkerbell is hosted there; harmless once Tinkerbell moves
+#    to this cluster)
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-egress-capi
+  namespace: capi-operator-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: coredns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-egress-capi
+  namespace: capi-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: coredns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-egress-capi
+  namespace: cabpt-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: coredns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-egress-capi
+  namespace: cacppt-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: coredns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# CAPT additionally reaches the external Tinkerbell cluster (cluster1,
+# 192.168.2.30:6443) while Tinkerbell is hosted there pre-migration.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-egress-capi
+  namespace: capt-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: coredns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    - toCIDR:
+        - 192.168.2.0/24
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP

--- a/clusters/cluster0/kubernetes/apps/networking/agentgateway/app/cilium-lb-ip-pool.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/agentgateway/app/cilium-lb-ip-pool.yaml
@@ -7,4 +7,4 @@ metadata:
   name: cluster0-lb-ip-pool
 spec:
   blocks:
-    - cidr: 87.58.147.51/32
+    - cidr: 192.168.2.31/32

--- a/clusters/cluster0/kubernetes/apps/networking/agentgateway/app/gateway.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/agentgateway/app/gateway.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: networking
 spec:
   gatewayClassName: agentgateway
+  infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: 192.168.2.31
+      lbipam.cilium.io/sharing-key: cluster0-edge
   listeners:
     - hostname: omni.biggs.dog
       name: omni-https

--- a/clusters/cluster0/kubernetes/apps/networking/ddns/app/cronjob.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/ddns/app/cronjob.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cloudflare-ddns
+  namespace: networking
+  labels:
+    app.kubernetes.io/name: cloudflare-ddns
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cloudflare-ddns
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: ddns
+              # favonia/cloudflare-ddns: small, non-root capable updater
+              image: docker.io/favonia/cloudflare-ddns:1.15.1
+              imagePullPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              env:
+                - name: CF_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cloudflare-api-token
+                      key: api-token
+                - name: DOMAINS
+                  value: home.biggs.dog
+                - name: IP6_PROVIDER
+                  value: none
+                - name: PROXIED
+                  value: "false"
+                - name: UPDATE_CRON
+                  value: "@never"   # CronJob owns the schedule
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi

--- a/clusters/cluster0/kubernetes/apps/networking/ddns/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/ddns/ks.yaml
@@ -1,13 +1,16 @@
+---
+# Keeps home.biggs.dog -> current WAN IP (external-dns CNAMEs the edge
+# hostnames to it). SUSPENDED until the cutover step (see external-dns/ks.yaml).
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app image-factory
+  name: &app ddns
   namespace: flux-system
 spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  path: ./clusters/cluster0/kubernetes/apps/omni/image-factory/app
+  path: ./clusters/cluster0/kubernetes/apps/networking/ddns/app
   prune: false
   sourceRef:
     kind: GitRepository
@@ -16,9 +19,6 @@ spec:
   interval: 3m
   retryInterval: 1m
   timeout: 5m
+  suspend: true
   dependsOn:
-    - name: openebs
     - name: secretstore
-    - name: issuers
-    - name: agentgateway
-    - name: dex

--- a/clusters/cluster0/kubernetes/apps/networking/external-dns/app/external-secret.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/external-dns/app/external-secret.yaml
@@ -1,0 +1,20 @@
+---
+# Same 1Password item cert-manager uses; the token needs Zone:DNS:Edit on the
+# biggs.dog zone (DNS-01 already requires it).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-api-token
+  namespace: networking
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudflare-api-token
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: cloudflare-api-token
+        property: api-token

--- a/clusters/cluster0/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# external-dns owns ONLY records it created (txtOwnerId + txtPrefix registry):
+# it CNAMEs omni/dex/netbird/factory to home.biggs.dog, whose A record is kept
+# current by the cloudflare-ddns CronJob (../ddns/). Each public HTTPRoute must
+# carry: external-dns.alpha.kubernetes.io/target: home.biggs.dog
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: networking
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: external-dns
+      version: "1.21.1"
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    provider:
+      name: cloudflare
+    sources:
+      - gateway-httproute
+    domainFilters:
+      - biggs.dog
+    policy: sync
+    txtOwnerId: cluster0
+    txtPrefix: extdns-
+    env:
+      - name: CF_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-token
+            key: api-token
+    extraArgs:
+      - --cloudflare-proxied=false
+      - --gateway-namespace=networking
+    podLabels:
+      app.kubernetes.io/name: external-dns

--- a/clusters/cluster0/kubernetes/apps/networking/external-dns/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/networking/external-dns/ks.yaml
@@ -1,0 +1,28 @@
+---
+# Publishes Cloudflare DNS for the edge hostnames from Gateway API routes
+# (Task 14b of the migration plan). SUSPENDED until the cutover step: enabling
+# it while UpCloud still owns the records would fight the existing A records
+# (Cloudflare rejects a CNAME over an A record). Unsuspend in the same commit
+# that deletes the old A records (plan Task 24).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-dns
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster0/kubernetes/apps/networking/external-dns/app
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 3m
+  retryInterval: 1m
+  timeout: 5m
+  suspend: true
+  dependsOn:
+    - name: secretstore
+    - name: agentgateway

--- a/clusters/cluster0/kubernetes/apps/omni/image-factory/app/httproute.yaml
+++ b/clusters/cluster0/kubernetes/apps/omni/image-factory/app/httproute.yaml
@@ -26,6 +26,9 @@ metadata:
   namespace: omni
   labels:
     app.kubernetes.io/name: image-factory
+  annotations:
+    # external-dns CNAMEs this hostname to home.biggs.dog (ddns-maintained WAN IP)
+    external-dns.alpha.kubernetes.io/target: home.biggs.dog
 spec:
   hostnames:
     - factory.biggs.dog

--- a/clusters/cluster0/kubernetes/apps/omni/omni/app/deployment.yaml
+++ b/clusters/cluster0/kubernetes/apps/omni/omni/app/deployment.yaml
@@ -59,9 +59,9 @@ spec:
             - --etcd-embedded-db-path=/_out/omni-etcd/
             - --sqlite-storage-path=/_out/sqlite/sqlite.db
             - --advertised-api-url=https://omni.biggs.dog/
-            - --machine-api-advertised-url=https://omni.biggs.dog:8090/
-            - --siderolink-wireguard-advertised-addr=87.58.147.51:50180
-            - --advertised-kubernetes-proxy-url=https://omni.biggs.dog:8100/
+            - --machine-api-advertised-url=https://192.168.2.31:8090/
+            - --siderolink-wireguard-advertised-addr=192.168.2.31:50180
+            - --advertised-kubernetes-proxy-url=https://192.168.2.31:8100/
             - --auth-auth0-enabled=false
             - --auth-oidc-enabled=true
             - --auth-oidc-provider-url=https://dex.biggs.dog

--- a/clusters/cluster0/kubernetes/apps/omni/omni/app/httproute.yaml
+++ b/clusters/cluster0/kubernetes/apps/omni/omni/app/httproute.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/name: omni
   annotations:
     agentgateway.dev/backend-protocol: "HTTPS"
+    # external-dns CNAMEs this hostname to home.biggs.dog (ddns-maintained WAN IP)
+    external-dns.alpha.kubernetes.io/target: home.biggs.dog
 spec:
   hostnames:
     - omni.biggs.dog

--- a/clusters/cluster0/kubernetes/apps/omni/omni/app/siderolink-service.yaml
+++ b/clusters/cluster0/kubernetes/apps/omni/omni/app/siderolink-service.yaml
@@ -1,19 +1,13 @@
 # SideroLink exposure (machine enrollment): machine-api/event-sink/k8s-proxy
 # (TCP 8090/8091/8100) + WireGuard (UDP 50180).
 #
-# The UpCloud Managed Load Balancer (type: LoadBalancer via the UpCloud CCM)
-# only supports TCP/HTTP frontends -- there is NO UDP mode (product-level
-# limitation). Because this Service includes UDP 50180, a LoadBalancer stays
-# pending forever (SyncLoadBalancerFailed, LB stuck at 'setup-server') -- the
-# same root cause as netbird-stun. agentgateway can't route UDP either. So
-# SideroLink is exposed directly on the node's public IP instead.
-#
-# 87.58.147.51 is bound on the node's eth2 (verified), and the single node owns
-# it, so externalIPs makes Cilium (kube-proxy-replacement) serve all four ports
-# (TCP + UDP) on the node's public NIC -> the omni pod. omni advertises
-# WireGuard at 87.58.147.51:50180 (--siderolink-wireguard-advertised-addr), so
-# this matches what machines are told to use. Reachability needs the UpCloud
-# firewall to allow inbound 8090/8091/8100 TCP + 50180 UDP. No cloud LB involved.
+# On-prem single-node cluster0 (2026-09 migration): the Cilium LB address is
+# the node's own IP 192.168.2.31 (cilium-lb-ip-pool.yaml), shared with the
+# agentgateway Service via the lbipam sharing key, so one address fronts all
+# edge protocols.
+# Machines (all on the LAN) reach SideroLink directly on the VIP, matching
+# --siderolink-wireguard-advertised-addr=192.168.2.31:50180. No WAN exposure:
+# nothing is forwarded from the UDM for these ports.
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,10 +15,11 @@ metadata:
   namespace: omni
   labels:
     app.kubernetes.io/name: omni
+  annotations:
+    lbipam.cilium.io/ips: 192.168.2.31
+    lbipam.cilium.io/sharing-key: cluster0-edge
 spec:
-  type: ClusterIP
-  externalIPs:
-    - 87.58.147.51 # node eth2 public IP (single-node cluster0)
+  type: LoadBalancer
   selector:
     app.kubernetes.io/name: omni
   ports:

--- a/clusters/cluster0/kubernetes/apps/omni/omni/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/omni/omni/ks.yaml
@@ -17,6 +17,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
   dependsOn:
+    - name: openebs
     - name: secretstore
     - name: issuers
     - name: dex

--- a/clusters/cluster0/kubernetes/apps/openebs/kustomization.yaml
+++ b/clusters/cluster0/kubernetes/apps/openebs/kustomization.yaml
@@ -2,6 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./agentgateway/ks.yaml
-  - ./external-dns/ks.yaml
-  - ./ddns/ks.yaml
+  - ./openebs/ks.yaml

--- a/clusters/cluster0/kubernetes/apps/openebs/namespace.yaml
+++ b/clusters/cluster0/kubernetes/apps/openebs/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openebs-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/clusters/cluster0/kubernetes/apps/openebs/openebs/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/openebs/openebs/app/helmrelease.yaml
@@ -1,0 +1,58 @@
+---
+# Local-path storage for the single-node Talos cluster0: backs the Omni
+# (etcd/sqlite), Image Factory registry, and NetBird PVCs. The basePath is
+# bind-mounted into the kubelet by the TalosControlPlane patch
+# (capi/clusters/management/cluster.yaml). host-path is the default SC; the
+# legacy upcloud-block-storage-maxiops name is gone (see netbird
+# server-deployment).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openebs
+  namespace: openebs-system
+spec:
+  interval: 3m
+  chart:
+    spec:
+      chart: openebs
+      version: 4.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: openebs
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    alloy:
+      enabled: false
+    openebs-crds:
+      csi:
+        volumeSnapshots:
+          enabled: false # snapshot-controller manages those CRDs
+    localpv-provisioner:
+      localpv:
+        basePath: /var/mnt/host-path
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule
+      hostpathClass:
+        name: host-path
+        isDefaultClass: true
+      analytics:
+        enabled: false
+      helperPod:
+        image:
+          registry: quay.io/
+    zfs-localpv:
+      enabled: false
+    lvm-localpv:
+      enabled: false
+    mayastor:
+      enabled: false

--- a/clusters/cluster0/kubernetes/apps/openebs/openebs/ks.yaml
+++ b/clusters/cluster0/kubernetes/apps/openebs/openebs/ks.yaml
@@ -1,13 +1,14 @@
+---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app image-factory
+  name: &app openebs
   namespace: flux-system
 spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  path: ./clusters/cluster0/kubernetes/apps/omni/image-factory/app
+  path: ./clusters/cluster0/kubernetes/apps/openebs/openebs/app
   prune: false
   sourceRef:
     kind: GitRepository
@@ -16,9 +17,3 @@ spec:
   interval: 3m
   retryInterval: 1m
   timeout: 5m
-  dependsOn:
-    - name: openebs
-    - name: secretstore
-    - name: issuers
-    - name: agentgateway
-    - name: dex

--- a/clusters/cluster1/kubernetes/apps/networking/lan-dns/app/configmap.yaml
+++ b/clusters/cluster1/kubernetes/apps/networking/lan-dns/app/configmap.yaml
@@ -17,6 +17,14 @@ data:
     biggs.dog:1053 {
         errors
         cache 30
+        # cluster0 on-prem cutover (2026-09 migration, plan Task 24): the four
+        # edge names move from the UpCloud public IP to the cluster0 node address. Uncomment
+        # in the same commit that flips Cloudflare to the ddns CNAMEs so LAN
+        # clients skip the WAN hairpin entirely.
+        # hosts {
+        #     192.168.2.31 omni.biggs.dog dex.biggs.dog netbird.biggs.dog factory.biggs.dog
+        #     fallthrough
+        # }
         # Forward to k8s-gateway's ClusterIP (NOT its .6.6 LB VIP): a pod reaching
         # a LoadBalancer VIP whose backend is on the SAME node hits a Cilium
         # hairpin failure, so the lan-dns replica co-located with k8s-gateway got


### PR DESCRIPTION
Second stacked PR of the cluster0 on-prem migration (plan: `.hermes/plans/2026-09-05_155530-cluster0-talos-mgmt-node.md`). Independent of #437 (A1) except both are needed before the bootstrap; merge order does not matter. Nothing here reconciles to a live cluster except the lan-dns comment (no-op) and, only if UpCloud comes back, the cluster0 tree (frozen/down).

## Changes

- **One address**: Cilium LB pool = the node's own IP `192.168.2.31/32` (decision 2026-09-05). `cluster0-gateway` (via `spec.infrastructure.annotations`), `omni-siderolink` (8090/8091/8100 TCP + 50180 UDP), and `netbird-stun` (3478 UDP) are `type: LoadBalancer` sharing it through `lbipam.cilium.io/sharing-key: cluster0-edge`. The UpCloud `externalIPs` workarounds (no-UDP cloud LB) are gone.
- **Omni** advertises `192.168.2.31` for SideroLink, machine-api, and k8s-proxy (LAN-only decision; only 80/443 and 3478/udp get UDM forwards).
- **openebs** 4.6.0 localpv host-path as the default SC (`/var/mnt/host-path`, bind-mounted by the TalosControlPlane patch in A1); Omni/image-factory/netbird gain `dependsOn: [openebs]`; netbird's PVC leaves `upcloud-block-storage-maxiops`.
- **Flux git auth** secret renamed to `flux-github-pat` (what knr-bootstrap seeds).
- **external-dns** 1.21.1 (`gateway-httproute` source, Cloudflare, `txtOwnerId: cluster0`, TXT-prefixed ownership so it never touches foreign records) + **cloudflare-ddns** CronJob (`favonia/cloudflare-ddns:1.15.1`) keeping `home.biggs.dog` on the WAN IP; the four edge HTTPRoutes CNAME to it via `external-dns.alpha.kubernetes.io/target`. Both Kustomizations are `suspend: true` until the cutover commit (plan Task 24), so merging this changes nothing live.
- **CNPs** for the CAPI namespaces (apiserver + DNS + world:443; CAPT also LAN `192.168.2.0/24:6443` for the external Tinkerbell on cluster1).
- **lan-dns**: commented `hosts` override for the four edge names (uncomment at cutover).

## Validation

- `kubectl kustomize` passes on every touched root (networking, omni, netbird, auth, openebs, network-policies, flux-system, cluster1/networking).
- `helm template` renders: openebs 4.6.0 (SC `host-path` with `is-default-class: "true"`), external-dns 1.21.1 (txt-owner-id/gateway-namespace/proxied args present).
- No `87.58.147.51` outside explanatory comments; no `192.168.2.41` anywhere.
