### PR TITLE
feat: temporary Tinkerbell stack on cluster1 for cluster0 PXE install

### DIFF
--- a/clusters/cluster1/flux-system/sources/kustomization.yaml
+++ b/clusters/cluster1/flux-system/sources/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - tinkerbell-oci.yaml
   - cnpg-repo.yaml
   - victoria-metrics-repo.yaml
   - nfd-repo.yaml

--- a/clusters/cluster1/flux-system/sources/tinkerbell-oci.yaml
+++ b/clusters/cluster1/flux-system/sources/tinkerbell-oci.yaml
@@ -1,0 +1,13 @@
+---
+# OCI chart source for the Tinkerbell stack (temporary cluster0 bootstrap
+# infra; removed when Tinkerbell relocates to cluster0).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tinkerbell
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: oci://ghcr.io/tinkerbell/charts/tinkerbell
+  ref:
+    tag: v0.25.0

--- a/clusters/cluster1/kubernetes/apps/network-policies/policies/infra/tinkerbell.yaml
+++ b/clusters/cluster1/kubernetes/apps/network-policies/policies/infra/tinkerbell.yaml
@@ -1,0 +1,57 @@
+# Namespace: tinkerbell (temporary cluster0 bootstrap infra).
+# The tinkerbell pod runs hostNetwork, which bypasses Cilium endpoint policy;
+# these rules document intent and cover any non-hostNetwork pods in the
+# namespace. Default-deny is implicit via endpointSelector: {}.
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-egress-tinkerbell
+  namespace: tinkerbell
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: coredns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    # hookos artifact download + action images (one-time, image pulls go to
+    # registries through the node's own egress, but the pod also fetches the
+    # hook artifacts tarball)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# Tootles metadata + smee iPXE HTTP from the LAN (the PXE-booting machine,
+# future Talos machines), Tink gRPC from HookOS workers, TFTP/proxyDHCP are
+# host-network UDP and not Cilium-policed.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-tinkerbell
+  namespace: tinkerbell
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromCIDR:
+        - 192.168.2.0/24
+      toPorts:
+        - ports:
+            - port: "7080"
+              protocol: TCP
+            - port: "42113"
+              protocol: TCP

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/capt-remote/app/rbac.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/capt-remote/app/rbac.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capt-remote
+  namespace: tinkerbell
+---
+# Hardware requires cluster-wide access: CAPT lists Hardware across all
+# namespaces before a target namespace is known.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capt-remote-hardware
+rules:
+  - apiGroups: ["tinkerbell.org"]
+    resources: ["hardware"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capt-remote-hardware
+subjects:
+  - kind: ServiceAccount
+    name: capt-remote
+    namespace: tinkerbell
+roleRef:
+  kind: ClusterRole
+  name: capt-remote-hardware
+  apiGroup: rbac.authorization.k8s.io
+---
+# Templates/Workflows/Jobs are created in the Hardware's namespace (default).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capt-remote
+  namespace: default
+rules:
+  - apiGroups: ["tinkerbell.org"]
+    resources: ["templates"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: ["tinkerbell.org"]
+    resources: ["workflows"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["bmc.tinkerbell.org"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capt-remote
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: capt-remote
+    namespace: tinkerbell
+roleRef:
+  kind: Role
+  name: capt-remote
+  apiGroup: rbac.authorization.k8s.io

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/capt-remote/ks.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/capt-remote/ks.yaml
@@ -1,0 +1,24 @@
+---
+# ServiceAccount + RBAC letting CAPT (in the kind bootstrap cluster, later on
+# cluster0) drive this Tinkerbell stack via --external-kubeconfig
+# (docs/REMOTE-TINKERBELL-KUBECONFIG.md in the CAPT repo).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tinkerbell-capt-remote
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster1/kubernetes/apps/tinkerbell/capt-remote/app
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 3m
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: tinkerbell

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/hardware/app/talos-mgmt-01.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/hardware/app/talos-mgmt-01.yaml
@@ -1,0 +1,40 @@
+---
+# The cluster0 management node (2026-09 migration). The name must equal
+# TinkerbellMachineTemplate.spec.template.spec.hardwareName in
+# clusters/cluster0/capi/clusters/management/cluster.yaml.
+# The installer-image annotation is consumed by the CAPT fork ->
+# TinkerbellMachine.status.installerImage -> CABPT machine.install.image and
+# governs in-place Talos upgrades. The initial install image is written by the
+# workflow template (../templates/).
+apiVersion: tinkerbell.org/v1alpha1
+kind: Hardware
+metadata:
+  name: talos-mgmt-01
+  namespace: default
+  annotations:
+    hardware.tinkerbell.org/installer-image: factory.talos.dev/metal-installer/3ae3a62ec7f0850f7a91ff15ea93ae4dc08ccb2dde627aaf83ee55b856b087cf:v1.14.0
+spec:
+  disks:
+    - device: /dev/nvme0n1
+  metadata:
+    instance:
+      hostname: cluster0-cp-01
+      id: 24:4b:fe:5c:d9:4a
+    facility:
+      facility_code: home
+  interfaces:
+    - dhcp:
+        arch: x86_64
+        hostname: cluster0-cp-01
+        ip:
+          address: 192.168.2.31
+          gateway: 192.168.2.1
+          netmask: 255.255.255.0
+        lease_time: 86400
+        mac: 24:4b:fe:5c:d9:4a
+        name_servers:
+          - 192.168.2.1
+        uefi: true
+      netboot:
+        allowPXE: true
+        allowWorkflow: true

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/hardware/ks.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/hardware/ks.yaml
@@ -1,0 +1,23 @@
+---
+# Hardware entry for the cluster0 management node. Applied with the stack; the
+# bench test (plan Phase C) drives it manually before CAPT takes over.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tinkerbell-hardware
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster1/kubernetes/apps/tinkerbell/hardware/app
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 3m
+  retryInterval: 1m
+  timeout: 2m
+  dependsOn:
+    - name: tinkerbell

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/kustomization.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./tinkerbell/ks.yaml
+  - ./capt-remote/ks.yaml
+  - ./hardware/ks.yaml
+  - ./templates/ks.yaml

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/namespace.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tinkerbell
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/templates/app/talos-metal.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/templates/app/talos-metal.yaml
@@ -1,0 +1,40 @@
+---
+# Tinkerbell workflow template for installing Talos on bare metal. CAPT's
+# generated default template is Ubuntu-shaped (oci2disk + cloud-init writefile
+# + kexec) and cannot install Talos; this override writes the Talos raw disk
+# image and reboots. Talos then fetches its machine config from Tootles via
+# the talos.config kernel arg baked into the Image Factory schematic
+# 3ae3a62e...87cf (talos.platform=metal,
+# talos.config=http://192.168.2.30:7080/2009-04-04/user-data).
+# Keep in sync with clusters/cluster0/capi/clusters/management/
+# talos-workflow-template.yaml (the CAPT-side copy).
+apiVersion: tinkerbell.org/v1alpha1
+kind: Template
+metadata:
+  name: talos-metal
+  namespace: default
+spec:
+  data: |
+    version: "0.1"
+    name: talos-metal
+    global_timeout: 3600
+    tasks:
+      - name: "install-talos"
+        worker: "{{.device_1}}"
+        volumes:
+          - /dev:/dev
+          - /dev/console:/dev/console
+        actions:
+          - name: "write-talos-raw-image"
+            # TODO(pin): pin by digest once the bench test passes
+            image: quay.io/tinkerbell/actions/image2disk:latest
+            timeout: 1200
+            environment:
+              IMG_URL: https://factory.talos.dev/image/3ae3a62ec7f0850f7a91ff15ea93ae4dc08ccb2dde627aaf83ee55b856b087cf/v1.14.0/metal-amd64.raw.xz
+              DEST_DISK: /dev/nvme0n1
+              COMPRESSED: "true"
+          - name: "reboot"
+            # TODO(pin): pin by digest once the bench test passes
+            image: quay.io/tinkerbell/actions/reboot:latest
+            timeout: 90
+            pid: host

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/templates/ks.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/templates/ks.yaml
@@ -1,0 +1,24 @@
+---
+# Talos provisioning workflow template, referenced by TinkerbellCluster
+# templateOverrideRef (cluster0 capi tree). Lives in the Tinkerbell cluster:
+# CAPT resolves the ref through its external Tinkerbell client.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tinkerbell-templates
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster1/kubernetes/apps/tinkerbell/templates/app
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 3m
+  retryInterval: 1m
+  timeout: 2m
+  dependsOn:
+    - name: tinkerbell

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/tinkerbell/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/tinkerbell/app/helmrelease.yaml
@@ -1,0 +1,60 @@
+---
+# Tinkerbell v0.25.0: single deployment running Smee (DHCP/TFTP/iPXE), the
+# Tink server + controller, and Tootles (EC2-style metadata, Hegel successor)
+# behind one HTTP server on 7080. hostNetwork on control-01 so proxyDHCP sees
+# L2 broadcasts (the init macvlan relay is disabled). The UDM remains the
+# network's DHCP server; Smee runs in proxy mode and only answers PXE clients.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tinkerbell
+  namespace: tinkerbell
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: tinkerbell
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    publicIP: 192.168.2.30
+    trustedProxies: []
+    # HookOS artifact downloads for PXE-booting machines (osie nginx runs
+    # hostNetwork on control-01, port 7173).
+    artifactsFileServer: http://192.168.2.30:7173
+    deployment:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/hostname: control-01
+      init:
+        enabled: false
+      envs:
+        globals:
+          publicIpv4: 192.168.2.30
+          enableRufioController: false   # no BMC on the target machine
+          enableSecondstar: false
+          enableUI: false
+        smee:
+          dhcpMode: proxy                # UDM keeps issuing leases
+          dhcpIPForPacket: 192.168.2.30
+          dhcpSyslogIP: 192.168.2.30
+          dhcpTftpIP: 192.168.2.30
+          dhcpIpxeHttpBinaryHost: 192.168.2.30
+          dhcpIpxeHttpScriptHost: 192.168.2.30
+          ipxeScriptTinkServerAddrPort: 192.168.2.30:42113
+    service:
+      enabled: false                     # hostNetwork replaces the LB
+    optional:
+      kubevip:
+        enabled: false
+      osie:
+        hostNetwork: true
+        nodeSelector:
+          kubernetes.io/hostname: control-01

--- a/clusters/cluster1/kubernetes/apps/tinkerbell/tinkerbell/ks.yaml
+++ b/clusters/cluster1/kubernetes/apps/tinkerbell/tinkerbell/ks.yaml
@@ -1,0 +1,22 @@
+---
+# Temporary Tinkerbell stack for PXE-installing the cluster0 management node
+# (2026-09 migration). Runs hostNetwork on control-01. Removed when Tinkerbell
+# relocates to cluster0 (plan Phase F).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tinkerbell
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./clusters/cluster1/kubernetes/apps/tinkerbell/tinkerbell/app
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 3m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Third stacked PR of the cluster0 on-prem migration (plan: `.hermes/plans/2026-09-05_155530-cluster0-talos-mgmt-node.md`; A1 #437, A2 #438). Independent of A1/A2 for merging. **This one reconciles live on cluster1 when merged** — it only adds the `tinkerbell` namespace and the objects below; nothing existing is modified.

## Contents

- **Tinkerbell v0.25.0** (OCI chart) as a single hostNetwork pod on `control-01`:
  - Smee `dhcpMode: proxy`: the UDM stays the network DHCP server; Smee only answers PXE clients. iPXE binaries/scripts on `192.168.2.30:7080`.
  - Tootles (Hegel successor) serves `Hardware.spec.userData` at `/2009-04-04/user-data` on the same 7080 HTTP server, selecting hardware by client IP. This is where Talos picks up its machine config (schematic kernel arg `talos.config=http://192.168.2.30:7080/2009-04-04/user-data`).
  - Rufio/Secondstar/UI disabled (no BMC); osie HookOS artifacts on `192.168.2.30:7173`; `service.enabled: false` and kube-vip off (hostNetwork).
- **`capt-remote` SA + RBAC** for CAPT `--external-kubeconfig`: Hardware needs a ClusterRole (cluster-wide list), Templates/Workflows/Jobs a Role in ns `default` (CAPT creates them in the Hardware's namespace).
- **Hardware `talos-mgmt-01`**: MAC `24:4b:fe:5c:d9:4a`, `192.168.2.31`, `/dev/nvme0n1`, `allowPXE/allowWorkflow: true`, installer-image annotation `factory.talos.dev/metal-installer/3ae3a62e...87cf:v1.14.0` (schematic created 2026-09-05: `intel-ucode`, `util-linux-tools`, `talos.platform=metal`, `talos.config` to Tootles).
- **Template `talos-metal`**: image2disk of the Talos raw image + reboot. CAPT resolves the cluster's `templateOverrideRef` through its external Tinkerbell client, so this must live here (verified in `controller/machine/template.go:158-175`).
- **CNPs** noting the hostNetwork exemption.

## Validation

- `kubectl kustomize` passes on `tinkerbell`, `network-policies`, `flux-system`.
- `helm template` of chart v0.25.0 with the committed values renders (14 objects): `hostNetwork: true`, `nodeSelector control-01`, `TINKERBELL_DHCP_MODE=proxy`, ports 7080/42113, osie hostNetwork. `artifactsFileServer` added after the chart's guard rejected the first render.

## After merge (Phase B gate, needs you at the machine)

1. `kubectl -n tinkerbell get pods` Running on control-01.
2. Set the target machine to UEFI network boot, power on with no Workflow present: Smee logs show the proxy offer for `24:4b:fe:5c:d9:4a` and an iPXE fetch; the machine lands in HookOS idle. Power off.
3. Then the Phase C bench test (manual Workflow, plan Task 17) and I generate the CAPT kubeconfig secret (plan Task 11) for the follow-up commit to #437's capt-system.
