### PR TITLE
fix: CAPI operator fetchConfig URLs must name the components file

### DIFF
--- a/clusters/cluster0/capi/capi-providers/cabpt-system/provider.yaml
+++ b/clusters/cluster0/capi/capi-providers/cabpt-system/provider.yaml
@@ -13,4 +13,4 @@ spec:
   # renovate: datasource=github-releases depName=sidero-community/cluster-api-bootstrap-provider-talos
   version: "v0.7.6"
   fetchConfig:
-    url: "https://github.com/sidero-community/cluster-api-bootstrap-provider-talos/releases"
+    url: "https://github.com/sidero-community/cluster-api-bootstrap-provider-talos/releases/v0.7.6/bootstrap-components.yaml"

--- a/clusters/cluster0/capi/capi-providers/cacppt-system/provider.yaml
+++ b/clusters/cluster0/capi/capi-providers/cacppt-system/provider.yaml
@@ -10,4 +10,4 @@ spec:
   # renovate: datasource=github-releases depName=sidero-community/cluster-api-control-plane-provider-talos
   version: "v0.6.4"
   fetchConfig:
-    url: "https://github.com/sidero-community/cluster-api-control-plane-provider-talos/releases"
+    url: "https://github.com/sidero-community/cluster-api-control-plane-provider-talos/releases/v0.6.4/control-plane-components.yaml"

--- a/clusters/cluster0/capi/capi-providers/capt-system/provider.yaml
+++ b/clusters/cluster0/capi/capi-providers/capt-system/provider.yaml
@@ -18,4 +18,4 @@ spec:
   # renovate: datasource=github-releases depName=shrinedogg/cluster-api-provider-tinkerbell
   version: "v0.7.1"
   fetchConfig:
-    url: "https://github.com/shrinedogg/cluster-api-provider-tinkerbell/releases"
+    url: "https://github.com/shrinedogg/cluster-api-provider-tinkerbell/releases/v0.7.1/infrastructure-components.yaml"


### PR DESCRIPTION
Second live finding from the kind bootstrap (after #441 unblocked cert-manager/capi-operator). All three non-kubeadm providers sit in `ComponentsFetchError`:

```
failed to create repo from provider url for provider "talos": error creating the GitHub repository client: invalid url:
a GitHub repository url should be in the form https://github.com/{owner}/{Repository}/releases/{latest|version-tag}/{componentsClient.yaml}
```

The `fetchConfig.url` values were copied verbatim from knr-ops `mgmt/local-talos` (bare `.../releases`), which has never had an acceptance run. The operator's GitHub client needs the components asset in the path. Fixed:

| Provider | URL |
|---|---|
| CABPT `talos` v0.7.6 | `.../cluster-api-bootstrap-provider-talos/releases/v0.7.6/bootstrap-components.yaml` |
| CACPPT `talos` v0.6.4 | `.../cluster-api-control-plane-provider-talos/releases/v0.6.4/control-plane-components.yaml` |
| CAPT `tinkerbell-tinkerbell` v0.7.1 | `.../shrinedogg/cluster-api-provider-tinkerbell/releases/v0.7.1/infrastructure-components.yaml` |

Asset names verified with `gh release view` on each tag. `bootstrap.toml` `provider-manifests` point at these same files, so the pivot applies the corrected URLs too.

Upstream: knr-ops `mgmt/local-talos/capi-providers/*/provider.yaml` and `docs/extending.md` carry the same bug; I'll include it in the knr-ops PR batch.
