### PR TITLE
fix: TalosControlPlane v1beta1 uses machineTemplate.spec.infrastructureRef

### DIFF
--- a/clusters/cluster0/capi/clusters/management/cluster.yaml
+++ b/clusters/cluster0/capi/clusters/management/cluster.yaml
@@ -58,10 +58,16 @@ spec:
   replicas: 1
   # renovate: datasource=github-releases depName=kubernetes/kubernetes
   version: "v1.36.0"
-  infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: TinkerbellMachineTemplate
-    name: cluster0
+  # CACPPT v0.6.4 serves v1beta1 (storage) with the modern CAPI v1beta2 KCP
+  # layout: the infra reference lives at machineTemplate.spec.infrastructureRef
+  # (the v1alpha3 field infrastructureTemplate only exists on the v1alpha3
+  # schema; knr-ops's v1beta1+v1alpha3 hybrid fails CRD validation).
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: TinkerbellMachineTemplate
+        name: cluster0
   controlPlaneConfig:
     controlplane:
       generateType: controlplane

--- a/clusters/cluster0/capi/clusters/management/cluster.yaml
+++ b/clusters/cluster0/capi/clusters/management/cluster.yaml
@@ -32,11 +32,11 @@ spec:
     host: 192.168.2.31
     port: 6443
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: TalosControlPlane
     name: cluster0
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: TinkerbellCluster
     name: cluster0
 ---
@@ -65,7 +65,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: cluster0
   controlPlaneConfig:
@@ -111,6 +111,10 @@ metadata:
 spec:
   template:
     spec:
-      # Direct hardware binding: the single management machine by its
-      # Tinkerbell Hardware CR name (hardware.yaml, same directory).
-      hardwareName: talos-mgmt-01
+      # Direct hardware binding: the single management machine, by label (the
+      # CAPT webhook forbids hardwareName in templates).
+      hardwareAffinity:
+        required:
+          - labelSelector:
+              matchLabels:
+                biggs.dog/cluster0-machine: "true"

--- a/clusters/cluster0/capi/clusters/management/hardware.yaml
+++ b/clusters/cluster0/capi/clusters/management/hardware.yaml
@@ -19,6 +19,8 @@ kind: Hardware
 metadata:
   name: talos-mgmt-01
   namespace: default
+  labels:
+    biggs.dog/cluster0-machine: "true"
   annotations:
     v1alpha1.tinkerbell.org/provisioned: "true"
     hardware.tinkerbell.org/installer-image: factory.talos.dev/metal-installer/2bbb0f87bfbce0f6062ac47225f915a07e2362786727d85377ae7ccab636813c:v1.14.0


### PR DESCRIPTION
Third live finding from the kind bootstrap. `cluster0-management` failed its dry-run:

```
TalosControlPlane/default/cluster0 dry-run failed: .spec.infrastructureTemplate: field not declared in schema
```

CACPPT v0.6.4's CRD serves two versions with different schemas:

- `v1alpha3` (not storage): `infrastructureTemplate` (ObjectReference), no `machineTemplate`
- `v1beta1` (storage): `machineTemplate.{metadata,spec.infrastructureRef}` (modern CAPI v1beta2 KCP layout), plus `machineNamingStrategy`

Our object declared `v1beta1` but used the v1alpha3 field name (verbatim from knr-ops, another latent local-talos bug for the upstream batch). `controlPlaneConfig.controlplane` (`generateType`, `talosVersion`, `strategicPatches`) is the same in both versions, so only the reference block changes.

Verified live against the installed CRD in kind: the fixed object passes `kubectl apply --dry-run=server` (returned `configured (server dry run)` for all four documents: Cluster, TinkerbellCluster, TalosControlPlane, TinkerbellMachineTemplate).
