### PR TITLE
fix: kubelet must register with the CAPT providerID

### DIFF
--- a/clusters/cluster0/capi/clusters/management/cluster.yaml
+++ b/clusters/cluster0/capi/clusters/management/cluster.yaml
@@ -97,6 +97,13 @@ spec:
                 enabled: true
                 port: 7445
             kubelet:
+              # CAPI node matching: CAPT replaces PROVIDER_ID with
+              # tinkerbell://<ns>/<hardware-name> when it stores the config on
+              # Hardware.spec.userData, so the kubelet registers with the
+              # providerID the Machine object carries. Without this the Machine
+              # never gains a nodeRef and clusterctl move refuses to run.
+              extraConfig:
+                providerID: PROVIDER_ID
               extraMounts:
                 - destination: /var/mnt/host-path
                   type: bind


### PR DESCRIPTION
Fourth live finding. After #443 the full chain ran: CAPT claimed the Hardware, wrote `userData`, the ISO boot installed Talos, and the node went Ready with Cilium — but `clusterctl move` refused:

```
cannot start the move operation while "/, Kind=" default/cluster0-klzql is still provisioning the node
```

The node registered with an empty `spec.providerID`, so the Machine (providerID `tinkerbell://default/talos-mgmt-01`) never got a `nodeRef`. Root cause: nothing in the generated Talos config sets the kubelet's providerID. CAPT already substitutes the literal `PROVIDER_ID` placeholder throughout `Hardware.spec.userData` (`controller/machine/hardware.go:176-186`), so the declarative fix is:

```yaml
machine:
  kubelet:
    extraConfig:
      providerID: PROVIDER_ID
```

Recovery already applied imperatively so the pivot could proceed: `kubectl patch node talos-z2j-iay --type merge -p '{"spec":{"providerID":"tinkerbell://default/talos-mgmt-01"}}'`; Machine flipped to `Running` with `nodeRef` immediately. This PR makes it declarative for future provisions; when it lands on the target post-pivot, CABPT's in-place update applies a config whose providerID equals the value already set (no-op).

Server dry-run passes against the live CRDs (4 documents). Another item for the knr-ops upstream batch (their local-talos cluster.yaml has the same gap).
