### PR TITLE
fix: DNS egress selectors must match Talos CoreDNS label; drop provider github; pin node nameservers

### DIFF
--- a/clusters/cluster0/capi/clusters/management/cluster.yaml
+++ b/clusters/cluster0/capi/clusters/management/cluster.yaml
@@ -87,6 +87,13 @@ spec:
             proxy:
               disabled: true        # Cilium kubeProxyReplacement
           machine:
+            network:
+              # DHCP on this VLAN hands out lan-dns (192.168.6.16, cluster1)
+              # first; with cluster1 down the first resolver blackholes and
+              # every lookup stalls ~4s. Pin working upstreams.
+              nameservers:
+                - 192.168.2.1
+                - 45.90.28.232
             install:
               # The raw image is written to disk by the Tinkerbell workflow;
               # this value governs in-place upgrades (image from

--- a/clusters/cluster0/flux-system/flux-operator/app/flux-instance.yaml
+++ b/clusters/cluster0/flux-system/flux-operator/app/flux-instance.yaml
@@ -64,5 +64,4 @@ spec:
     url: "https://github.com/shrinedogg/biggs.dog.git"
     ref: "refs/heads/main"
     path: "clusters/cluster0"
-    provider: github
     pullSecret: "flux-github-pat"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/apps/auth.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/apps/auth.yaml
@@ -20,9 +20,13 @@ spec:
   endpointSelector: {}
   egress:
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/apps/netbird.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/apps/netbird.yaml
@@ -21,9 +21,13 @@ spec:
   endpointSelector: {}
   egress:
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/apps/omni.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/apps/omni.yaml
@@ -22,9 +22,13 @@ spec:
   endpointSelector: {}
   egress:
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"
@@ -58,6 +62,8 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+# CoreDNS label note: on fresh Talos the built-in CoreDNS pods carry
+# k8s-app: kube-dns (not coredns); DNS egress selectors match BOTH labels.
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/capi.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/capi.yaml
@@ -9,6 +9,8 @@
 #  - LAN 192.168.2.0/24:6443 (CAPT reaches the EXTERNAL Tinkerbell API on
 #    cluster1 while Tinkerbell is hosted there; harmless once Tinkerbell moves
 #    to this cluster)
+# CoreDNS label note: on fresh Talos the built-in CoreDNS pods carry
+# k8s-app: kube-dns (not coredns); DNS egress selectors match BOTH labels.
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -21,9 +23,13 @@ spec:
     - toEntities:
         - kube-apiserver
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"
@@ -51,9 +57,13 @@ spec:
     - toEntities:
         - kube-apiserver
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"
@@ -81,9 +91,13 @@ spec:
     - toEntities:
         - kube-apiserver
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"
@@ -111,9 +125,13 @@ spec:
     - toEntities:
         - kube-apiserver
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"
@@ -143,9 +161,13 @@ spec:
     - toEntities:
         - kube-apiserver
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/cert-manager.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/cert-manager.yaml
@@ -22,9 +22,13 @@ spec:
   endpointSelector: {}
   egress:
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/external-secrets.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/external-secrets.yaml
@@ -19,9 +19,13 @@ spec:
   endpointSelector: {}
   egress:
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/flux-system.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/flux-system.yaml
@@ -24,9 +24,13 @@ spec:
   endpointSelector: {}
   egress:
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/networking.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/networking.yaml
@@ -19,9 +19,13 @@ spec:
   endpointSelector: {}
   egress:
     - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-            k8s:k8s-app: coredns
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values: [kube-system]
+            - key: k8s:k8s-app
+              operator: In
+              values: [coredns, kube-dns]
       toPorts:
         - ports:
             - port: "53"

--- a/clusters/cluster1/flux-system/flux-operator/app/flux-instance.yaml
+++ b/clusters/cluster1/flux-system/flux-operator/app/flux-instance.yaml
@@ -64,5 +64,4 @@ spec:
     url: "https://github.com/shrinedogg/biggs.dog.git"
     ref: "refs/heads/main"
     path: "clusters/cluster1"
-    provider: github
     pullSecret: "flux-system"


### PR DESCRIPTION
Three live findings from the first full-tree reconcile on the Talos cluster0 node. These currently block convergence: everything DNS-dependent (source-controller, helm repos, cert-manager) is down until this merges and Flux re-applies.

## 1. CNP DNS selectors (the hard blocker)

Fresh Talos labels its built-in CoreDNS pods `k8s-app: kube-dns`, not `coredns`. The biggs.dog `allow-egress-dns` pattern selects `k8s-app: coredns`, so the moment `network-policies-infra` first applied on the new node, DNS egress was denied for every managed namespace (source-controller, helm-controller, cert-manager...). Symptom: `lookup github.com on 10.96.0.10:53: i/o timeout` from flux-system pods while `default`-namespace pods resolve fine.

All 8 files switched to `matchExpressions` with `k8s-app In [coredns, kube-dns]` (13 selector sites). cluster1 is unaffected (its CoreDNS is the custom `k8s-app: coredns` deployment; the selector now matches both, so the same files stay correct there).

## 2. `provider: github` + PAT rejected by Flux 2.9

`secretRef with github app data must be specified when provider is set to github` (fluxcd/source-controller#1860 made GitHub App data mandatory for `provider: github`; PAT basic auth only works with `generic`). Dropped `sync.provider` from **both** FluxInstances. cluster1's identical line would hit the same error when its Flux is re-seeded at rebuild; the live cluster0 FluxInstance was patched imperatively to unblock (this PR makes it permanent).

## 3. Node nameservers

The node VLAN's DHCP hands lan-dns (`192.168.6.16`, on cluster1, down) as the first resolver: every lookup stalls ~4s before falling through, which was the original cause of the source-controller timeouts. `machine.network.nameservers: [192.168.2.1, 45.90.28.232]` added to the TalosControlPlane patch (live node already patched; applied without reboot).

Validated: `kubectl kustomize` on network-policies + capi roots; server dry-run of the patched flux-system CNPs (5 documents) passes.
