### PR TITLE
fix: onepassword-connect CNPs must select the chart's app label

### DIFF
--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/cert-manager.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/cert-manager.yaml
@@ -70,6 +70,10 @@ spec:
   egress:
     - toFQDNs:
         - matchName: api.cloudflare.com
+        # ACME issuers: account registration + DNS-01 order flow (cluster1 has
+        # no cert-manager CNP, so this was never covered there either).
+        - matchName: acme-v02.api.letsencrypt.org
+        - matchName: acme-staging-v02.api.letsencrypt.org
       toPorts:
         - ports:
             - port: "443"

--- a/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/external-secrets.yaml
+++ b/clusters/cluster0/kubernetes/apps/network-policies/policies/infra/external-secrets.yaml
@@ -2,6 +2,9 @@
 #
 # The ClusterSecretStore routes through onepassword-connect on port 8080.
 # connect-sync dials *.1password.com over HTTPS to pull vault changes.
+# The connect chart (2.4.1) labels its pods `app: onepassword-connect` (there is
+# NO app.kubernetes.io/name label); selectors referencing that name select zero
+# pods and connect-sync loses 1Password egress (408 from the Connect API).
 ---
 # NOTE: No standalone default-deny policy — Cilium rejects an empty deny-all
 # (VALID: False, "rule must have at least one of Ingress/Egress"). Default-deny
@@ -66,7 +69,7 @@ spec:
   egress:
     - toEndpoints:
         - matchLabels:
-            app.kubernetes.io/name: onepassword-connect
+            app: onepassword-connect
       toPorts:
         - ports:
             - port: "8080"
@@ -81,7 +84,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: onepassword-connect
+      app: onepassword-connect
   ingress:
     - fromEndpoints:
         - matchLabels:
@@ -101,7 +104,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: onepassword-connect
+      app: onepassword-connect
   egress:
     - toEntities:
         - world


### PR DESCRIPTION
Fifth live finding on the new cluster0. The three onepassword-connect selectors in `network-policies/policies/infra/external-secrets.yaml` use `app.kubernetes.io/name: onepassword-connect`, but the connect chart 2.4.1 labels its pods `app: onepassword-connect` (no `app.kubernetes.io/name`). Everything under the `external-secrets` default-deny then lost 1Password access:

- connect-sync: `Post https://my.1password.com/api/v3/auth/start: i/o timeout` (policy drop, no CNP allowed world:443)
- Connect API: `awaiting healthy syncer` -> 408 on every validation
- ClusterSecretStore: `InvalidProviderConfig`
- every ExternalSecret (cloudflare-api-token for DNS-01 certs, Dex/Omni/NetBird/factory secrets): `SecretSyncedError`

cluster1 has no `external-secrets` infra CNP, so this selector bug was invisible there; it came with the cluster0 policy set (never exercised on UpCloud either).

Fix: all three selectors now use `app: onepassword-connect`, with a comment explaining the label. Live CNPs are already patched so the store is recovering; this PR makes it stick (the KS would otherwise revert it).

Verified live after patching: connect-sync reached `token received, getting credentials and initializing API` (the remaining i/o timeout cleared once the selector matched).
