### PR TITLE
fix: openebs values must disable the full umbrella stack for cluster0

### DIFF
--- a/clusters/cluster0/kubernetes/apps/openebs/openebs/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/openebs/openebs/app/helmrelease.yaml
@@ -50,9 +50,27 @@ spec:
       helperPod:
         image:
           registry: quay.io/
+    # cluster0 wants ONLY localpv-provisioner (hostpath). The 4.6.0 umbrella
+    # chart deploys the etcd/nats/loki/minio/diskpool stack and the zfs+lvm
+    # node DaemonSets unless both the legacy flags and the engines block say
+    # no (helm install timed out on all of them on the single node; the zfs
+    # node DS crashloops without a zpool).
     zfs-localpv:
       enabled: false
     lvm-localpv:
       enabled: false
     mayastor:
       enabled: false
+    loki:
+      enabled: false
+    minio:
+      enabled: false
+    engines:
+      local:
+        lvm:
+          enabled: false
+        zfs:
+          enabled: false
+      replicated:
+        mayastor:
+          enabled: false


### PR DESCRIPTION
The cluster0 openebs install failed:

```
Helm install failed ... timeout waiting for: [Deployment/openebs-operator-diskpool, StatefulSet/openebs-etcd,
StatefulSet/openebs-nats, StatefulSet/openebs-loki, StatefulSet/openebs-minio,
Deployment/openebs-zfs-localpv-controller, DaemonSet/openebs-zfs-localpv-node, ...]
```

The A2 values only flipped the legacy engine flags (`zfs-localpv/lvm-localpv/mayastor.enabled: false`), which in chart 4.6.0 does not stop the umbrella's etcd/nats/loki/minio/diskpool stack or the zfs/lvm node DaemonSets. On a single node that is all dead weight (and the zfs node crashloops: no zpool).

This mirrors cluster1's disable pattern with zfs also off: adds `loki`/`minio` off and the `engines` block (`local.lvm/zfs`, `replicated.mayastor` off). Render check with the committed values: no etcd/nats/loki/minio/zfs/lvm/mayastor objects; localpv-provisioner + host-path StorageClass render intact.

After merge the helm-controller retries the install with the slimmed values.
