### PR TITLE
fix: pin edge names to the gateway VIP via coredns-custom inlineManifest

### DIFF
--- a/clusters/cluster0/capi/clusters/management/cluster.yaml
+++ b/clusters/cluster0/capi/clusters/management/cluster.yaml
@@ -86,6 +86,53 @@ spec:
                 name: none          # Cilium via ClusterResourceSet (cilium-crs.yaml)
             proxy:
               disabled: true        # Cilium kubeProxyReplacement
+            # Edge names resolve to the cluster0 gateway VIP in-cluster (public
+            # DNS still points at the retired UpCloud IP until the WAN cutover).
+            # Without this, Omni's OIDC discovery to dex.biggs.dog leaves the
+            # cluster and crashes the pod. Same coredns-custom pattern as
+            # cluster1's Omni template.
+            inlineManifests:
+              - name: coredns-custom
+                contents: |
+                  apiVersion: v1
+                  kind: ConfigMap
+                  metadata:
+                    name: coredns
+                    namespace: kube-system
+                  data:
+                    Corefile: |
+                      .:53 {
+                          errors
+                          health {
+                              lameduck 5s
+                          }
+                          ready
+                          log . {
+                              class error
+                          }
+                          prometheus :9153
+
+                          hosts {
+                              192.168.2.31 omni.biggs.dog dex.biggs.dog netbird.biggs.dog factory.biggs.dog home.biggs.dog
+                              fallthrough
+                          }
+
+                          kubernetes cluster.local in-addr.arpa ip6.arpa {
+                              pods insecure
+                              fallthrough in-addr.arpa ip6.arpa
+                              ttl 30
+                          }
+                          forward . /etc/resolv.conf {
+                             max_concurrent 1000
+                          }
+                          cache 30 {
+                             disable success cluster.local
+                             disable denial cluster.local
+                          }
+                          loop
+                          reload
+                          loadbalance
+                      }
           machine:
             network:
               # DHCP on this VLAN hands out lan-dns (192.168.6.16, cluster1)


### PR DESCRIPTION
Omni crashlooped at startup: `Get https://dex.biggs.dog/.well-known/openid-configuration: dial tcp 87.58.147.51:443: connect: connection refused` — in-cluster pods resolve the edge names via public DNS to the retired UpCloud IP. The Corefile was patched live (hosts override for the five names -> 192.168.2.31, the shared gateway VIP) and Omni is Running; this commit makes the override declarative in the TalosControlPlane strategic patch (same `coredns-custom` inlineManifest pattern as cluster1's Omni cluster template) so it survives a node rebuild.

Note: the agentgateway dataplane had to be restarted once the certs were issued — it booted before cert-manager had any TLS secrets and wedged serving plain HTTP on the :443 listeners. Worth watching if the gateway ever precedes cert issuance again.
