### PR TITLE
revert: coredns inlineManifest must not live in the TalosControlPlane

### DIFF
--- a/clusters/cluster0/capi/clusters/management/cluster.yaml
+++ b/clusters/cluster0/capi/clusters/management/cluster.yaml
@@ -86,53 +86,15 @@ spec:
                 name: none          # Cilium via ClusterResourceSet (cilium-crs.yaml)
             proxy:
               disabled: true        # Cilium kubeProxyReplacement
-            # Edge names resolve to the cluster0 gateway VIP in-cluster (public
-            # DNS still points at the retired UpCloud IP until the WAN cutover).
-            # Without this, Omni's OIDC discovery to dex.biggs.dog leaves the
-            # cluster and crashes the pod. Same coredns-custom pattern as
-            # cluster1's Omni template.
-            inlineManifests:
-              - name: coredns-custom
-                contents: |
-                  apiVersion: v1
-                  kind: ConfigMap
-                  metadata:
-                    name: coredns
-                    namespace: kube-system
-                  data:
-                    Corefile: |
-                      .:53 {
-                          errors
-                          health {
-                              lameduck 5s
-                          }
-                          ready
-                          log . {
-                              class error
-                          }
-                          prometheus :9153
-
-                          hosts {
-                              192.168.2.31 omni.biggs.dog dex.biggs.dog netbird.biggs.dog factory.biggs.dog home.biggs.dog
-                              fallthrough
-                          }
-
-                          kubernetes cluster.local in-addr.arpa ip6.arpa {
-                              pods insecure
-                              fallthrough in-addr.arpa ip6.arpa
-                              ttl 30
-                          }
-                          forward . /etc/resolv.conf {
-                             max_concurrent 1000
-                          }
-                          cache 30 {
-                             disable success cluster.local
-                             disable denial cluster.local
-                          }
-                          loop
-                          reload
-                          loadbalance
-                      }
+            # NOTE: the coredns edge-names hosts override (omni/dex/netbird/
+            # factory/home.biggs.dog -> 192.168.2.31, the gateway VIP) is a
+            # MANUAL post-bootstrap step, not an inlineManifest here: CABPT
+            # v0.6.4 has no in-place rollout strategy, so any
+            # controlPlaneConfig change replaces the control-plane machine.
+            # On this single-node cluster that reinstalls the node from the
+            # ISO. The live override is in the kube-system/coredns ConfigMap
+            # (same coredns-custom pattern as cluster1's Omni template);
+            # re-apply it after any node rebuild.
           machine:
             network:
               # DHCP on this VLAN hands out lan-dns (192.168.6.16, cluster1)


### PR DESCRIPTION
Reverts #448.

Applying it taught us something important about this stack: **CABPT v0.6.4 has no in-place rollout strategy** (CRD offers only `RollingUpdate`/`OnDelete`). Any change to `controlPlaneConfig` (including `strategicPatches`) changes the template hash and CABPT creates a replacement machine — it already created `cluster0-bntfg`, which can never go ready here (single node, one Hardware), and if hardware freed up it would wipe and reinstall the node from the ISO. Control-plane config changes on this cluster are effectively "rebuild the node" operations and must be treated that way.

Reverting restores the spec hash to match the running machine, which abandons the rollout. The coredns edge-names override stays live in the `kube-system/coredns` ConfigMap and is now documented in-file as a manual post-bootstrap step (re-apply after node rebuilds, same as cluster1's Omni-template pattern).

After merge: Flux re-applies, the pending `cluster0-bntfg` TinkerbellMachine gets removed by the controller; I'll verify.
