### PR TITLE
fix: restore byte-identical strategicPatches (CABPT hashes comments too)

### DIFF
--- a/clusters/cluster0/capi/clusters/management/cluster.yaml
+++ b/clusters/cluster0/capi/clusters/management/cluster.yaml
@@ -74,6 +74,14 @@ spec:
       # Major.minor contract version only (docs/extending.md Talos rule).
       # renovate: datasource=github-releases depName=siderolabs/talos
       talosVersion: v1.14
+      # WARNING: every byte inside strategicPatches is hashed by CABPT --
+      # comments included. Changing anything here (even a comment) replaces
+      # the control-plane MACHINE (no in-place strategy in v0.6.4), which on
+      # this single-node cluster means reinstalling the node from the ISO.
+      # Related: the coredns edge-names hosts override (omni/dex/netbird/
+      # factory/home.biggs.dog -> 192.168.2.31, the gateway VIP) is a MANUAL
+      # post-bootstrap step in the kube-system/coredns ConfigMap, NOT an
+      # inlineManifest here, for exactly this reason. Re-apply after rebuilds.
       strategicPatches:
         - |
           cluster:
@@ -86,15 +94,6 @@ spec:
                 name: none          # Cilium via ClusterResourceSet (cilium-crs.yaml)
             proxy:
               disabled: true        # Cilium kubeProxyReplacement
-            # NOTE: the coredns edge-names hosts override (omni/dex/netbird/
-            # factory/home.biggs.dog -> 192.168.2.31, the gateway VIP) is a
-            # MANUAL post-bootstrap step, not an inlineManifest here: CABPT
-            # v0.6.4 has no in-place rollout strategy, so any
-            # controlPlaneConfig change replaces the control-plane machine.
-            # On this single-node cluster that reinstalls the node from the
-            # ISO. The live override is in the kube-system/coredns ConfigMap
-            # (same coredns-custom pattern as cluster1's Omni template);
-            # re-apply it after any node rebuild.
           machine:
             network:
               # DHCP on this VLAN hands out lan-dns (192.168.6.16, cluster1)


### PR DESCRIPTION
Follow-up to #449 — my revert wasn't a true revert: I left an explanatory comment **inside** the `strategicPatches` block scalar. CABPT hashes the raw patch string (comments included), so the live `TalosControlPlane` no longer matches the running machine's template:

```
"rolling out control plane machines" needRollout=["cluster0-klzql","cluster0-bntfg"]
"waiting for all nodes to finish boot sequence" error="no addresses were found for node \"cluster0-bntfg\""
```

Both machines are now marked for replacement, stuck only because the spare machine can't boot. If hardware ever freed up, CABPT would wipe and reinstall the node.

This moves the explanation outside the string (file-level YAML comments never reach the API) and restores the exact pre-#448 bytes — verified `git diff 71470a80` on this file is empty outside the new file-level comment. After merge the rollout abandons and `cluster0-bntfg` is deleted by the controller.

**Standing rule** (now in the file): treat every byte inside `strategicPatches` as load-bearing; review diffs there like schema changes.
