### PR TITLE
docs: audit and update README.md and docs/NOTES.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# 🐕 biggs.dog
+# biggs.dog
 
-> Biggs was my dog. He was the best boy and when I found out I could buy a domain with `.dog` as the extension, I migrated my homelab services to biggs.dog to honor him.
+> Biggs was my dog. He was the best boy and when I found out I could buy a domain with .dog as the extension, I migrated my homelab services to biggs.dog to honor him.
 
-## 📖 Overview
+## Overview
 
-This is a mono repository for my home infrastructure and Kubernetes clusters, following Infrastructure as Code (IaC) and GitOps practices using [Flux](https://fluxcd.io/). Desired state lives in Git; Flux reconciles it into the clusters.
+This is a mono repository for home infrastructure and Kubernetes clusters, following Infrastructure as Code (IaC) and GitOps practices using [Flux](https://fluxcd.io/). Desired state lives in Git; Flux reconciles it into the clusters.
 
-The homelab is split across **two clusters** (an in-progress migration — see [Architecture](#-architecture)):
+The homelab is split across **two clusters**:
 
-- **`cluster0`** — a single-node cloud cluster on [UpCloud](https://upcloud.com/) (public WAN IP `87.58.147.51`) acting as the **edge / management plane**: public ingress, identity (Dex), VPN (NetBird), and the Talos management plane (Omni).
-- **`cluster1`** — the **on-prem bare-metal workload cluster** (the original 6-node homelab): all applications, storage, GPU/AI workloads, and observability.
+- **`cluster0`** - an on-prem single-node [Talos Linux](https://www.talos.dev/) management cluster (LAN IP `192.168.2.31`) acting as the **management plane**: the Talos management plane ([Omni](https://omni.siderolabs.io/)), Talos Image Factory, root identity ([Dex](https://dexidp.io/)), [OpenEBS](https://openebs.io/) storage, the Cluster API (CAPI) management subtree, cert-manager, external-secrets, and Cilium CNI. Remote access uses the UniFi Dream Machine (UDM) built-in VPN.
+- **`cluster1`** - the **on-prem bare-metal workload cluster** (6 nodes: `control-01`, `nv-01`, `worker-01` through `worker-04`) running Talos Linux `v1.13.8` with Kubernetes `v1.36.3`: all applications, Rook-Ceph distributed storage, OpenEBS storage, GPU/AI workloads (RTX 5090 on `nv-01`), media, communication, and observability.
 
-## 🏗️ Architecture
+## Architecture
 
 ### GitOps with Flux
 
 Each cluster runs its own [Flux Operator](https://fluxcd.controlplane.io/operator/) instance syncing a dedicated path on the `main` branch of this repository:
 
-| Cluster  | Sync path            | Flux distribution | Contents                                                                 |
-| -------- | -------------------- | ----------------- | ------------------------------------------------------------------------ |
-| `cluster0` | `clusters/cluster0`  | Flux `2.9.0`      | Edge/mgmt: Dex, NetBird, Omni, Image Factory, cert-manager, external-secrets, Cilium, network policies |
-| `cluster1` | `clusters/cluster1`  | Flux `2.9.0`      | All workloads: apps, storage, database, AI/agents, observability, etc.   |
+| Cluster | Sync path | Flux distribution | Contents |
+| --- | --- | --- | --- |
+| `cluster0` | `clusters/cluster0` | Flux `2.9.0` | Management plane: Dex, Omni, Image Factory, CAPI management subtree, cert-manager, external-secrets, OpenEBS, Cilium, network policies |
+| `cluster1` | `clusters/cluster1` | Flux `2.9.0` | Workloads: applications, Rook-Ceph and OpenEBS storage, CloudNativePG, AI/agents, observability, network policies |
 
 Flux components on each cluster: Source Controller, Kustomize Controller, Helm Controller, Notification Controller.
 
@@ -28,268 +28,275 @@ Flux components on each cluster: Source Controller, Kustomize Controller, Helm C
 
 ```
 clusters/
-├── cluster0/                      # ⛅ UpCloud cloud edge/mgmt cluster (single node)
-│   ├── flux-system/               # FluxInstance + HelmRepository/OCIRepository sources
+├── cluster0/                      # On-prem Talos management cluster (single node, 192.168.2.31)
+│   ├── capi/                      # Cluster API management subtree (CAPI operator, Tinkerbell, providers)
+│   │   ├── capi-providers/        # CAPI, CABPT, CACPPT, CAPT provider definitions
+│   │   ├── clusters/management/   # Management cluster CRs (Hardware, Cluster, TalosControlPlane, CRS)
+│   │   ├── infrastructure/        # CAPI operator and Tinkerbell manifests
+│   │   └── sources/               # CAPI Helm and OCI sources
+│   ├── flux-system/               # FluxInstance + sources
 │   └── kubernetes/apps/
 │       ├── auth/dex/              # Dex OIDC IdP (root identity for edge apps)
 │       ├── cert-manager/          # Certificate issuance (ACME + CA issuers)
 │       ├── external-secrets/      # External Secrets + 1Password Connect
-│       ├── kube-system/cilium/    # Cilium CNI (L2 announcement, single WAN IP)
-│       ├── netbird/               # NetBird WireGuard VPN (road-warrior access)
+│       ├── kube-system/cilium/    # Cilium CNI (L2 announcement, 192.168.2.31/32)
 │       ├── network-policies/      # CiliumNetworkPolicies (two-tier: apps + infra)
-│       ├── networking/            # agentgateway (public ingress) + Cilium LB/L2
-│       └── omni/
-│           ├── omni/              # Sidero Omni (in-cluster Talos management plane)
-│           └── image-factory/     # Talos image factory
-└── cluster1/                      # 🏠 On-prem bare-metal workload cluster (6 nodes)
+│       ├── networking/            # agentgateway (cluster0-gateway) + Cloudflare DDNS
+│       ├── omni/
+│       │   ├── omni/              # Sidero Omni (Talos management plane for cluster1)
+│       │   └── image-factory/     # Talos image factory
+│       └── openebs/               # OpenEBS localpv host-path storage
+└── cluster1/                      # On-prem bare-metal workload cluster (6 nodes)
     ├── flux-system/               # FluxInstance + sources
     └── kubernetes/apps/
-        ├── ai-system/             # vLLM + kagent agents + substrate runtime + Flux/VM/Exa MCP
+        ├── ai-system/             # vLLM + kagent agents + substrate runtime + MCP servers
         ├── auth/                  # SSO stack (Pocket ID + OAuth2 Proxy)
         ├── biggs/                 # Tribute
         ├── cert-manager/          # Certificate issuance (ACME + CA issuers)
-        ├── cnpg/                  # CloudNativePG databases
+        ├── cnpg/                  # CloudNativePG databases + Barman Cloud
         ├── dragonfly/             # Redis-compatible cache
-        ├── dreamcast/             # GPU game streaming (Fenrir/Wolf + NVIDIA GPU Operator)
+        ├── dreamcast/             # GPU game streaming (Fenrir/Wolf + NVIDIA GPU Operator + GPU Arbiter)
         ├── external-secrets/      # External Secrets + 1Password Connect
         ├── games/                 # Dedicated game servers (Windrose)
-        ├── livekit/             # LiveKit SFU (WebRTC media server for MatrixRTC)
         ├── kube-system/           # Cilium (BGP), CoreDNS, NFD, GPU plugins, storage
         ├── liquidctl/             # NZXT Kraken Elite AIO fan/pump control (nv-01)
-        ├── matrix/                # Continuwuity (Matrix)
+        ├── livekit/               # LiveKit SFU (WebRTC media server for MatrixRTC)
+        ├── matrix/                # Continuwuity (Matrix) + Sable client
         ├── media/                 # Emby, Bookboss, Ersatz, Nsyncd
         ├── mindwtr/               # Mindwtr notes PWA + self-hosted sync server
         ├── network-policies/      # Tiered CiliumNetworkPolicies (apps + infra)
-        ├── networking/            # k8s-gateway, lan-dns, agentgateway (LAN + public)
+        ├── networking/            # k8s-gateway, lan-dns, agentgateway (wildcard-biggs-dog)
         ├── observability/         # VictoriaMetrics/Logs, Grafana Operator
         ├── openebs/               # Container-attached storage
         ├── renovate/              # Automated dependency updates
-        └── rook-ceph/             # Distributed storage
+        └── rook-ceph/             # Distributed storage (Rook v1.20 + Ceph CSI driver)
 ```
 
-## 🖥️ Cluster Nodes
+## Cluster Nodes
 
-### `cluster1` — on-prem bare metal
+### `cluster1` - on-prem bare metal
 
-Six bare-metal nodes managed via [Omni](https://omni.siderolabs.io/) (now run in-cluster on `cluster0` — see [Core Components](#-core-components)), all running **Talos Linux v1.13.5** with Kubernetes **v1.36.2**. This is where all workloads (and the GPU) live.
+Six bare-metal nodes managed via self-hosted [Omni](https://omni.siderolabs.io/) running on `cluster0` (`omni.biggs.dog`, context `self-hosted`, cluster `biggs-dog`), all running **Talos Linux v1.13.8** with Kubernetes **v1.36.3**. This is where workloads and the GPU reside.
 
-| Hostname     | Role          | CPU                                          | RAM    | GPU                                                                          |
-| ------------ | ------------- | -------------------------------------------- | ------ | ---------------------------------------------------------------------------- |
-| `control-01` | control-plane | AMD EPYC 4564P (16C / 32T)                   | 128 GB | AMD Radeon iGPU (Raphael, `1002:164e`, unused)                               |
-| `nv-01`      | worker        | AMD Ryzen 7 7800X3D (8C / 16T)              | 64 GB  | **NVIDIA GeForce RTX 5090** dGPU (32 GB, `10de:2b85`, time-sliced ×4) + AMD Radeon iGPU |
-| `worker-01`  | worker        | Intel Core Ultra 5 225H (Arrow Lake-H, 14T) | 32 GB  | Intel Arc Graphics iGPU (`8086:7d51`)                                        |
-| `worker-02`  | worker        | Intel Core i7-1360P (Raptor Lake-P, 16T)    | 32 GB  | Intel Iris Xe Graphics iGPU (`8086:a7a0`)                                    |
-| `worker-03`  | worker        | Intel Core i7-1360P (Raptor Lake-P, 16T)    | 32 GB  | Intel Iris Xe Graphics iGPU (`8086:a7a0`)                                    |
-| `worker-04`  | worker        | Intel Core Ultra 5 125H (Meteor Lake, 18T)  | 32 GB  | Intel Arc Graphics iGPU (`8086:7d55`)                                        |
+| Hostname | Role | CPU | RAM | GPU |
+| --- | --- | --- | --- | --- |
+| `control-01` | control-plane | AMD EPYC 4564P (16C / 32T) | 128 GB | AMD Radeon iGPU (Raphael, `1002:164e`, unused) |
+| `nv-01` | worker | AMD Ryzen 7 7800X3D (8C / 16T) | 64 GB | **NVIDIA GeForce RTX 5090** dGPU (32 GB, `10de:2b85`, time-sliced x4) + AMD Radeon iGPU |
+| `worker-01` | worker | Intel Core Ultra 5 225H (Arrow Lake-H, 14T) | 32 GB | Intel Arc Graphics iGPU (`8086:7d51`) |
+| `worker-02` | worker | Intel Core i7-1360P (Raptor Lake-P, 16T) | 32 GB | Intel Iris Xe Graphics iGPU (`8086:a7a0`) |
+| `worker-03` | worker | Intel Core i7-1360P (Raptor Lake-P, 16T) | 32 GB | Intel Iris Xe Graphics iGPU (`8086:a7a0`) |
+| `worker-04` | worker | Intel Core Ultra 5 125H (Meteor Lake, 18T) | 32 GB | Intel Arc Graphics iGPU (`8086:7d55`) |
 
-### `cluster0` — cloud edge (UpCloud)
+### `cluster0` - on-prem management node
 
-A single-node cluster hosted on UpCloud, exposed on the public WAN IP `87.58.147.51`. It fronts the homelab (public ingress via Cloudflare → agentgateway) and runs the identity, VPN, and Talos-management planes. Node specs are cloud-VM sized and not pinned in this repo. VIP advertisement uses a Cilium L2 announcement policy with a single-IP pool (`87.58.147.51/32`); the UpCloud Managed LB only supports TCP/HTTP (no UDP), so UDP services like NetBird STUN are exposed via `externalIPs` bound on the node's NIC instead of a LoadBalancer Service.
+A single-node Talos management cluster (`talos-mgmt-01` / `cluster0-cp-01`) on the LAN at `192.168.2.31`, running **Talos Linux v1.14** with Kubernetes **v1.36.0**. Bootstrapped using `knr-bootstrap` (knr-ops `local-talos` pattern) via Cluster API (CAPI) with Tinkerbell and Talos providers (`bootstrap.toml`). It hosts the Talos management plane (Omni), Talos Image Factory, root identity (Dex), and OpenEBS storage. Cilium advertises the node IP (`192.168.2.31/32`) via an L2 announcement policy shared between `cluster0-gateway` and `omni-siderolink`.
 
-> **GPU notes (`cluster1`):** The Intel iGPUs are exposed to workloads via the Intel GPU device plugin for media transcoding. `nv-01`'s RTX 5090 is time-sliced into 4 `nvidia.com/gpu` replicas. vLLM (the in-cluster LLM, see [AI & Agents](#-ai--agents)) and the [Dreamcast game-streaming stack](#-dreamcast-game-streaming-stack) can't coexist on the 32 GB card (vLLM alone pins ~27–31 GB), so the [GPU Arbiter](#gpu-arbiter) scales vLLM to 0 for the duration of any gaming session and restores it after; the time-slices then serve the session's Wolf sidecar + game container plus an always-on GPU-tuning DaemonSet. The AMD integrated graphics on the two AMD nodes are present but unused (nodes run headless).
+> **GPU notes (`cluster1`):** The Intel iGPUs are exposed to workloads via the Intel GPU device plugin for media transcoding. `nv-01`'s RTX 5090 is time-sliced into 4 `nvidia.com/gpu` replicas. vLLM (the in-cluster LLM, see [AI and Agents](#ai-and-agents)) and the [Dreamcast game streaming stack](#dreamcast-game-streaming-stack) cannot coexist on the 32 GB card (vLLM pins ~22-30 GB), so the [GPU Arbiter](#gpu-arbiter) scales vLLM to 0 for the duration of any gaming session and restores it after. The time-slices then serve the session's Wolf sidecar + game container plus an always-on GPU-tuning DaemonSet. `nv-01` runs an ASRock X870E Taichi Lite motherboard, a Samsung 9100 PRO 1TB install disk, a Realtek RTL8126 5GbE NIC (`enp9s0`), and Sidero Talos kernel-signed open GPU modules (`595.71.05`). The AMD integrated graphics on the two AMD nodes are present but unused (nodes run headless).
 
-## 🔧 Core Components
+> **Storage disk selection notes (`cluster1`):** Workers carry two NVMe drives. Linux NVMe drive enumeration order (`/dev/nvme0n1` vs `/dev/nvme1n1`) is unstable across reboots on multi-drive hosts. Talos install drives are pinned by hardware serial via `machine.install.diskSelector` in the Omni cluster template. Rook-Ceph OSDs (one Micron 7450 960 GB NVMe per worker) are pinned by persistent by-id paths (`/dev/disk/by-id/nvme-Micron_7450_..._<serial>`).
+
+## Core Components
 
 ### Networking
 
-| Cluster   | Component                                                | Description                                                  |
-| --------- | -------------------------------------------------------- | ------------------------------------------------------------ |
-| both      | [Cilium](https://cilium.io/)                             | CNI (kube-proxy replacement). `cluster0`: L2 announcement + single-IP pool (`87.58.147.51/32`). `cluster1`: BGP peering with the UDM (ASN 64564 ↔ 64563) advertising LoadBalancer IPs from `192.168.6.6–254`. |
-| `cluster1` | [k8s-gateway](https://github.com/ori-edge/k8s_gateway)   | Split-horizon DNS authoritative for `*.biggs.dog` (LB `192.168.6.6`, ClusterIP `10.105.74.41`) |
-| `cluster1` | lan-dns                                                  | LAN resolver (CoreDNS, LB `192.168.6.16`): forwards `biggs.dog` → k8s-gateway (split-horizon) and everything else → NextDNS over DoT (encrypted upstream). The UDM hands out `.6.16` via per-VLAN DHCP. |
-| both      | [Gateway API](https://gateway-api.sigs.k8s.io/)          | Kubernetes ingress using Gateway API                         |
-| both      | [AgentGateway](https://github.com/kgateway-dev/kgateway) | Gateway API implementation; OCI charts pinned to a known-good alpha build (`0.0.0-alpha.a655af15`). |
+| Cluster | Component | Description |
+| --- | --- | --- |
+| both | [Cilium](https://cilium.io/) | CNI (kube-proxy replacement). `cluster0`: L2 announcement + single-IP pool (`192.168.2.31/32`). `cluster1`: BGP peering with the UDM (ASN 64564 <-> 64563) advertising LoadBalancer IPs from `192.168.6.6-254`. |
+| `cluster1` | [k8s-gateway](https://github.com/ori-edge/k8s_gateway) | Split-horizon DNS authoritative for `*.biggs.dog` (LB `192.168.6.6`, ClusterIP `10.101.183.97`, 2 replicas). Contains a hosts block mapping `omni.biggs.dog`, `dex.biggs.dog`, `factory.biggs.dog` to `192.168.2.31` locally before fallthrough to NextDNS. |
+| `cluster1` | lan-dns | LAN resolver (CoreDNS, LB `192.168.6.16`): contains a hosts block for cluster0 edge names to `192.168.2.31`, forwards `biggs.dog` to k8s-gateway's ClusterIP (`10.101.183.97`), and forwards everything else to NextDNS over DoT (`tls://45.90.28.0`, `tls://45.90.30.0`). The UDM hands out `.6.16` via per-VLAN DHCP. |
+| both | [Gateway API](https://gateway-api.sigs.k8s.io/) | Kubernetes ingress using Gateway API. `cluster1` runs `wildcard-biggs-dog` (LB `192.168.6.7`), fronted by UDM port forwards on 80/443. `cluster0` runs `cluster0-gateway` (LB `192.168.2.31`). |
+| both | [AgentGateway](https://github.com/kgateway-dev/kgateway) | Gateway API implementation with OCI charts pinned to a verified build. |
 
-`cluster1` DNS: LAN clients resolve `biggs.dog` via **lan-dns** (`192.168.6.16`), which forwards to k8s-gateway for internal VIPs and to NextDNS over DoT for everything else. In-cluster, **CoreDNS** (kube-dns, Talos-managed) forwards `biggs.dog` to k8s-gateway's ClusterIP (`10.105.74.41`), so pods resolve `*.biggs.dog` internally instead of hairpinning through Cloudflare. Both forward targets use the ClusterIP (not the LB VIP) to avoid a Cilium same-node LB hairpin failure when a resolver pod is co-located with k8s-gateway.
+`cluster1` DNS: LAN clients resolve `biggs.dog` via **lan-dns** (`192.168.6.16`), which forwards to k8s-gateway for internal VIPs and to NextDNS over DoT for everything else. In-cluster, **CoreDNS** (kube-dns, Talos-managed) forwards `biggs.dog` to k8s-gateway's ClusterIP (`10.101.183.97`), so pods resolve `*.biggs.dog` internally instead of hairpinning through Cloudflare. Both forward targets use the ClusterIP (not the LB VIP) to avoid a Cilium same-node LB hairpin failure when a resolver pod is co-located with k8s-gateway.
 
-`cluster0` ingress is the `cluster0-gateway` (`networking` namespace) with HTTPS listeners for the edge hostnames `omni.biggs.dog`, `dex.biggs.dog`, and `netbird.biggs.dog` (TLS terminated with per-host certs issued in the `networking` namespace via the `letsencrypt-prod` ClusterIssuer — DNS-01/Cloudflare), plus a wildcard `*.biggs.dog` HTTP listener. Omni re-encrypts to its pod's own cert (HTTPS backend).
+`cluster0` ingress is `cluster0-gateway` (`networking` namespace) with HTTPS listeners for `omni.biggs.dog`, `dex.biggs.dog`, and `factory.biggs.dog` (TLS terminated with per-host certs issued in the `networking` namespace via the `letsencrypt-prod` ClusterIssuer), plus a wildcard `*.biggs.dog` HTTP listener. Omni re-encrypts to its pod cert (HTTPS backend via BackendTLSPolicy).
 
 **Service-specific gateways:**
-- **ersatz** (`cluster1`, game server): LAN-only HTTPS gateway at `ersatz.biggs.dog`
+- **ersatz** (`cluster1`, media server): LAN-only HTTPS gateway at `ersatz.biggs.dog`
+- **internal-biggs-dog** (`cluster1`): LAN-only gateway (VIP `192.168.6.15`) for internal routes including `mcp.biggs.dog` and `mindwtr.biggs.dog`
 
-### Storage  (`cluster1`)
+### Storage (`cluster1`)
 
-| Component                                                                     | Description                                  |
-| ----------------------------------------------------------------------------- | -------------------------------------------- |
-| [Rook-Ceph](https://rook.io/)                                                 | Distributed storage cluster                  |
-| [OpenEBS](https://openebs.io/)                                                | Container attached storage                   |
-| [Volsync](https://volsync.readthedocs.io/)                                    | Backup and replication of persistent volumes |
-| [Snapshot Controller](https://github.com/kubernetes-csi/external-snapshotter) | CSI volume snapshots                         |
-| NFS CSI Driver                                                                | NFS storage provisioner                      |
-| ZFS                                                                           | ZFS volume management                        |
+| Component | Description |
+| --- | --- |
+| [Rook-Ceph](https://rook.io/) | Distributed block storage cluster (`ceph-block` StorageClass, pool `ceph-blockpool` size 3) on four OSDs (Micron 7450 960 GB NVMe per worker). Rook v1.20 with ceph-csi-operator Driver and OperatorConfig CRs in git (`rook-ceph/csi-rbac/drivers.yaml`). Cluster fsid `37a406cf-68c2-4131-96e7-f7b7c050b2c4` preserved via mon-store adoption. |
+| [OpenEBS](https://openebs.io/) | Container attached storage (localpv host-path provisioner, chart `4.6.0` on both clusters). |
+| [Volsync](https://volsync.readthedocs.io/) | Backup and replication of persistent volumes to Backblaze B2 (chart `0.16.0`). Cache PVCs pinned to `ceph-block`. |
+| [Snapshot Controller](https://github.com/kubernetes-csi/external-snapshotter) | CSI volume snapshots (chart `5.2.0`). |
+| NFS CSI Driver | NFS storage provisioner (chart `4.13.4`). |
+| ZFS | ZFS volume management. |
 
-### Database  (`cluster1`)
+### Database (`cluster1`)
 
-| Component                                   | Description                                    |
-| ------------------------------------------- | ---------------------------------------------- |
-| [CloudNativePG](https://cloudnative-pg.io/) | PostgreSQL operator for in-cluster databases   |
-| [Barman Cloud](https://pgbarman.org/)       | CNPG plugin for PostgreSQL backup and recovery |
-| [Dragonfly](https://www.dragonflydb.io/)    | Redis-compatible in-memory datastore           |
+| Component | Description |
+| --- | --- |
+| [CloudNativePG](https://cloudnative-pg.io/) | PostgreSQL operator for in-cluster databases (chart `0.29.0`, PG18 minimal Trixie image catalog). |
+| [Barman Cloud](https://pgbarman.org/) | CNPG plugin (`0.7.1`) for PostgreSQL backup and recovery to object storage. |
+| [Dragonfly](https://www.dragonflydb.io/) | Redis-compatible in-memory datastore. |
 
-### Security & Secrets  (both)
+### Security and Secrets (both)
 
-| Component                                                          | Description                                     |
-| ------------------------------------------------------------------ | ----------------------------------------------- |
-| [cert-manager](https://cert-manager.io/)                           | Certificate management with CA and ACME issuers |
-| [External Secrets](https://external-secrets.io/)                   | Sync secrets from external providers            |
+| Component | Description |
+| --- | --- |
+| [cert-manager](https://cert-manager.io/) | Certificate management with CA and ACME issuers (chart `v1.21.1` on both clusters). |
+| [External Secrets](https://external-secrets.io/) | Sync secrets from external providers (chart `2.9.0` on both clusters). |
 | [1Password Connect](https://developer.1password.com/docs/connect/) | Secret backend for External Secrets. The `connect` chart (`v2.4.1`) is deployed on **both** clusters, with its `1password-credentials.json` and API `token` shipped as **SOPS-encrypted Secrets in Git** (decrypted in-cluster by Flux's `sops-age` key), not inline chart values. |
-| [SOPS](https://github.com/getsops/sops)                            | Encrypted secrets (age key). The repo-wide age key was rotated on 2026-07-04; `sops.yaml` now lists the deployed key plus a pre-staged next key. |
+| [SOPS](https://github.com/getsops/sops) | Encrypted secrets (age key). The repo-wide age key is configured in `.sops.yaml`. |
 
-### Network Policies  (`cluster1` and `cluster0`)
+### Network Policies (`cluster1` and `cluster0`)
 
 Both clusters run a least-privilege [CiliumNetworkPolicy](https://docs.cilium.io/en/stable/security/policy/) posture. Policies live centrally in `apps/network-policies/policies/` and are wired through **two independent Flux Kustomizations** so the rollout can be staged and rolled back per-tier:
 
-- **`cluster1`** — `network-policies-apps` (`policies/apps/`) covers lower-risk application namespaces (auth, biggs, dragonfly, games, jitsi, matrix, media, renovate). `network-policies-infra` (`policies/infra/`) covers higher-risk infrastructure namespaces (networking, ai-system, cnpg-system, observability, rook-ceph, plus a scoped `kube-system` policy covering only the Hubble relay/UI pods).
-- **`cluster0`** — `network-policies-apps` covers auth (Dex), netbird, and omni. `network-policies-infra` covers networking (agentgateway), cert-manager, external-secrets, flux-system, and Cilium L2 announcement. Suspend independently with `flux suspend kustomization network-policies-infra` if the edge or control plane regresses.
+- **`cluster1`** - `network-policies-apps` (`policies/apps/`) covers application namespaces (auth, biggs, dragonfly, dreamcast, games, livekit, matrix, media, mindwtr, renovate). `network-policies-infra` (`policies/infra/`) covers infrastructure namespaces (networking, ai-system, cnpg-system, observability, rook-ceph, plus a scoped `kube-system` policy covering Hubble relay/UI pods).
+- **`cluster0`** - `network-policies-apps` covers auth (Dex) and omni. `network-policies-infra` covers networking (agentgateway), cert-manager, external-secrets, flux-system, and capi. Suspend independently with `flux suspend kustomization network-policies-infra` if the control plane regresses.
 
-### Identity & SSO
+### Identity and SSO
 
-The two clusters run **different identity stacks**:
+The two clusters run different identity stacks:
 
-**`cluster0` (edge) — Dex** (`dex.biggs.dog`):
-[Dex](https://dexidp.io/) (`v2.45.1`) is the root OIDC identity provider for the edge plane, backing Omni. It runs stateless (`storage.type: memory`) with `enablePasswordDB: true` and a static admin user; clients/secrets are templated into the config from 1Password. Config lives in `apps/auth/dex/`.
+**`cluster0` (management) - Dex** (`dex.biggs.dog`):
+[Dex](https://dexidp.io/) (`v2.45.1`) is the root OIDC identity provider for the management plane, backing Omni and Image Factory. It runs stateless (`storage.type: memory`) with `enablePasswordDB: true` and a static admin user; clients and secrets are templated into the config from 1Password. Config lives in `clusters/cluster0/kubernetes/apps/auth/dex/`.
 
-| Component                                       | Description                                                                                       |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [Dex](https://dexidp.io/) (`cluster0`)          | Root OIDC IdP for edge apps (Omni, Image Factory). Stateless, static admin user. |
-| [Pocket ID](https://github.com/pocket-id/pocket-id) (`cluster1`) | Passkey-based OIDC provider at `id.biggs.dog` (Postgres via CNPG, uploads stored in the database) |
-| [OAuth2 Proxy](https://github.com/oauth2-proxy/oauth2-proxy) (`cluster1`) | OIDC client at `auth.biggs.dog`; forward-auth for apps with a shared `.biggs.dog` session cookie  |
+| Component | Description |
+| --- | --- |
+| [Dex](https://dexidp.io/) (`cluster0`) | Root OIDC IdP for management apps (Omni, Image Factory). Stateless, static admin user. |
+| [Pocket ID](https://github.com/pocket-id/pocket-id) (`cluster1`) | Passkey-based OIDC provider at `id.biggs.dog` (image `v2.14.0`, Postgres via CNPG, uploads stored in database). |
+| [OAuth2 Proxy](https://github.com/oauth2-proxy/oauth2-proxy) (`cluster1`) | OIDC client at `auth.biggs.dog` (image `v7.15.4`, chart `10.7.0`); forward-auth for apps with a shared `.biggs.dog` session cookie. |
 
-On `cluster1`, protected apps attach an agentgateway `AgentgatewayPolicy` with `traffic.extAuth` that calls OAuth2 Proxy's `/oauth2/auth` endpoint and redirects unauthenticated users to the Pocket ID sign-in. OAuth2 Proxy uses **Dragonfly (Redis) for session storage** so the browser cookie stays a small session ticket (a cookie-based session carrying tokens grows past 4 KB, gets chunked, and didn't survive the ext-authz subrequest — causing a forward-auth redirect loop).
+On `cluster1`, protected apps attach an agentgateway `AgentgatewayPolicy` with `traffic.extAuth` that calls OAuth2 Proxy's `/oauth2/auth` endpoint and redirects unauthenticated users to Pocket ID sign-in. OAuth2 Proxy uses **Dragonfly (Redis) for session storage** so the browser cookie stays a small session ticket.
 
-- **Forward-auth (`cluster1`, via OAuth2 Proxy):** Rook-Ceph dashboard, Bookboss, kagent UI, Mindwtr (browser PWA only — its `/v1` sync API stays bearer-token so CLI/mobile clients can still authenticate)
-- **Native OIDC (`cluster1`, direct Pocket ID client):** Grafana
+- **Forward-auth (`cluster1`, via OAuth2 Proxy):** Rook-Ceph dashboard, Bookboss, kagent UI, Mindwtr (browser PWA only; the `/v1` sync API uses bearer tokens for CLI and mobile sync).
+- **Native OIDC (`cluster1`, direct Pocket ID client):** Grafana.
 
-> NetBird (≥ v0.65) authenticates against its **own embedded IdP**; the `cluster0` Dex is attached to that embedded IdP as an upstream OIDC connector at runtime (NetBird dashboard → Settings → Identity Provider). The dashboard never talks to Dex directly.
+### Observability (`cluster1`)
 
-### Observability  (`cluster1`)
+| Component | Description |
+| --- | --- |
+| [VictoriaMetrics](https://victoriametrics.com/) | Metrics storage and monitoring (`victoria-metrics-k8s-stack` chart `0.91.2`). |
+| [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) | Log aggregation (chart `0.13.9` single, `0.3.7` collector; includes Talos kernel logs with GPU Xid alerting). |
+| [Grafana Operator](https://grafana.github.io/grafana-operator/) | Grafana deployment and dashboard management (chart `10.5.15`). |
 
-| Component                                                       | Description                                 |
-| --------------------------------------------------------------- | ------------------------------------------- |
-| [Victoria Metrics](https://victoriametrics.com/)                | Metrics storage and monitoring              |
-| [Victoria Logs](https://docs.victoriametrics.com/victorialogs/) | Log aggregation (includes Talos kernel logs with GPU Xid alerting) |
-| [Grafana Operator](https://grafana.github.io/grafana-operator/) | Grafana deployment and dashboard management |
+### System (`cluster1`)
 
-### System  (`cluster1`)
+| Component | Description |
+| --- | --- |
+| [Node Feature Discovery](https://kubernetes-sigs.github.io/node-feature-discovery/) | Hardware feature detection. |
+| Intel GPU Plugin | Intel GPU device plugin for hardware media transcoding acceleration. |
+| [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) | NVIDIA device plugin with GPU time-slicing (chart `v26.7.0`; driver and toolkit provided by Talos system extensions). |
 
-| Component                                                                           | Description                                                                                     |
-| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [Node Feature Discovery](https://kubernetes-sigs.github.io/node-feature-discovery/) | Hardware feature detection                                                                      |
-| Intel GPU Plugin                                                                    | Intel GPU device plugin for hardware acceleration                                               |
-| [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)                       | NVIDIA device plugin with GPU time-slicing (driver/toolkit provided by Talos system extensions) |
+### Management Plane (`cluster0`)
 
-### Edge / Management Plane  (`cluster0`)
-
-| Component                                       | Description                                                                                          |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [NetBird](https://netbird.io/)                  | Zero-config WireGuard VPN for road-warrior access to the homelab. Combined server (mgmt + signal + relay + STUN + embedded IdP) at `netbird.biggs.dog` (`0.74.2`) plus a dashboard. SQLite store on a 1Gi PVC (`Recreate`). STUN/UDP 3478 exposed via `externalIPs` (`87.58.147.51`) because the UpCloud Managed LB has no UDP mode. gRPC routes use an `AgentgatewayPolicy` to force HTTP/2 backend protocol. |
-|[Omni](https://omni.siderolabs.io/) (Sidero)    | In-cluster Talos management plane at `omni.biggs.dog` (`v1.10.0`): UI, machine API, Siderolink (WireGuard `:50180`), and Kubernetes-in-Kubernetes proxy. Manages the on-prem `cluster1` nodes (which phone home over Siderolink). Runs privileged with `/dev/net/tun`; double-TLS via `BackendTLSPolicy` (gateway re-encrypts to the pod's own Let's Encrypt cert using System CA trust). |
-| [Talos Image Factory](https://www.talos.dev/latest/learnmore/image-factory/) | Builds and signs custom Talos Linux images with cosign. Stateless HTTP service (`ghcr.io/siderolabs/image-factory:v1.4.0`) behind an `oauth2-proxy` authenticated against Dex at `factory.biggs.dog`. |
-| [Dex](https://dexidp.io/)                       | See [Identity & SSO](#identity--sso).                                                                |
+| Component | Description |
+| --- | --- |
+| [Omni](https://omni.siderolabs.io/) (Sidero) | In-cluster Talos management plane at `omni.biggs.dog` (`v1.10.5`): UI, machine API (`:8090`), event sink (`:8091`), Kubernetes proxy (`:8100`), and Siderolink WireGuard (`:50180/udp`). Sole manager of `cluster1` nodes (which phone home over Siderolink). Backed by embedded etcd + SQLite PVCs on OpenEBS; OIDC login via Dex. |
+| [Talos Image Factory](https://www.talos.dev/latest/learnmore/image-factory/) | Builds and signs custom Talos Linux images with cosign (`ghcr.io/siderolabs/image-factory:v1.6.0`). Stateless HTTP service behind OAuth2 Proxy authenticated against Dex at `factory.biggs.dog`. Durable state in registry PVC on OpenEBS. |
+| [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/) | CAPI operator (`0.28.0`), core CAPI `v1.14`, CABPT `v0.7.6`, CACPPT `v0.6.4`, and CAPT `v0.7.1` (Tinkerbell) managing the single on-prem management node. |
+| [Dex](https://dexidp.io/) | Root OIDC identity provider for Omni and Image Factory. See [Identity and SSO](#identity-and-sso). |
+| [OpenEBS](https://openebs.io/) | Localpv host-path provisioner backing Omni and Image Factory persistent volumes. |
+| Cloudflare DDNS | CronJob (`docker.io/favonia/cloudflare-ddns:1.15.1`) updating dynamic DNS. |
 
 ### Automation
 
-| Component                                 | Description                                                                  |
-| ----------------------------------------- | ---------------------------------------------------------------------------- |
-| [Renovate](https://docs.renovatebot.com/) (`cluster1`) | Automated dependency updates (HelmRelease chart versions + container images) |
+| Component | Description |
+| --- | --- |
+| [Renovate](https://docs.renovatebot.com/) (`cluster1`) | Automated dependency updates (`ghcr.io/mend/renovate-ce:15.4.0` for HelmRelease chart versions and container images). |
 
-
-## 📺 Applications  (`cluster1`)
+## Applications
 
 | Category | Applications | Notes |
-| -------- | ------------ | ----- |
-| **Authentication** | Pocket ID, OAuth2 Proxy | Passkey-first OIDC SSO for all apps |
-| **Media** | Emby, Bookboss, Ersatz, Nsyncd | Content & book management |
-| **Communication** | LiveKit SFU, Continuwuity (Matrix) | WebRTC media server for MatrixRTC & messaging |
+| --- | --- | --- |
+| **Authentication** | Pocket ID, OAuth2 Proxy | Passkey-first OIDC SSO for applications |
+| **Media** | Emby, Bookboss, Ersatz, Nsyncd | Content and book management (`emby:4.10.0.29`, `bookboss:v0.8.34`) |
+| **Communication** | LiveKit SFU, Continuwuity, Sable | WebRTC media server (`livekit:v1.13.6`), Matrix homeserver, Sable Matrix web client |
 | **Task Management** | Mindwtr, mindwtr-agent | Offline PWA + self-hosted sync server; GTD agent with MCP tools |
-| **Game Streaming** | Fenrir / Wolf | GPU-accelerated Moonlight streaming (see [Dreamcast](#-dreamcast-game-streaming-stack)) |
-| **Game Servers** | Windrose Online | Persistent MMO on Wine backend |
-| **Hardware** | liquidctl | NZXT Kraken Elite AIO fan/pump curves on `nv-01` (privileged, raw USB HID) |
+| **Game Streaming** | Fenrir / Wolf | GPU-accelerated Moonlight streaming (see [Dreamcast Game Streaming Stack](#dreamcast-game-streaming-stack)) |
+| **Game Servers** | Windrose Online | Dedicated MMO server on Wine backend (`windrose:0.10.0.7.33-372c3516`) |
+| **Hardware** | liquidctl | NZXT Kraken Elite AIO fan and pump curves on `nv-01` (privileged, raw USB HID) |
 | **Other** | biggs | Tribute |
 
-Detailed app deployment configs are in `clusters/cluster1/kubernetes/apps/<namespace>/`.
+Detailed application deployment configurations are in `clusters/cluster1/kubernetes/apps/<namespace>/`.
 
-## 🎮 Dreamcast Game Streaming Stack  (`cluster1`)
+## Dreamcast Game Streaming Stack
 
 The `dreamcast` namespace is an on-demand, GPU-accelerated game-streaming platform built on [Games on Whales](https://games-on-whales.github.io/) Fenrir/Wolf. A [Moonlight](https://moonlight-stream.org/) client pairs with an in-cluster `moonlight-proxy`, and the `direwolf-operator` spins up a per-session pod (Wolf compositor + the app) on the NVIDIA node, encodes the desktop with NVENC, and streams it back over RTSP/RTP.
 
 ### Components
 
 | Component | Description |
-| --------- | ----------- |
-| [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) | `gpu-operator` Helm chart with `driver` and `toolkit` **disabled** — on Talos the driver ships via the `nonfree-kmod-nvidia` system extension and the container toolkit via a system extension + machine config, so the operator only runs NFD + device plugin. The single physical GPU is **time-sliced into 4 `nvidia.com/gpu` replicas**: one is held by the `nvidia-gpu-tuning` DaemonSet (below), the rest serve a session's Wolf sidecar + game container. vLLM consumes one when idle but is scaled to 0 during sessions (see [GPU Arbiter](#gpu-arbiter)). |
-| [Fenrir / direwolf-operator](https://github.com/games-on-whales/fenrir) | Operator (installed from an OCI HelmRelease) that reconciles `App`/`User`/`Session`/`Pairing` CRDs and creates session pods. Fronted by `moonlight-proxy`. |
-| [Wolf](https://games-on-whales.github.io/wolf/) | Per-session streaming sidecar: Wayland compositor, GStreamer + NVENC video pipeline, PulseAudio capture, and virtual input. |
-| [gpu-arbiter-operator](https://github.com/shrinedogg/gpu-arbiter-operator) (custom) | controller-runtime operator that reconciles a cluster-scoped `GPUArbiter` CR: scales the `vllm` Deployment to 0 whenever an `alex-steam`/`direwolf-worker` session pod appears in `dreamcast`, and back to 1 when idle, then lifts the `gpu.biggs.dog/await-vram` scheduling gate once VRAM is free (vLLM down, DCGM free-VRAM above threshold, or a safety timeout). Replaces the original `alpine/k8s` bash loop. Without it the session and vLLM would both claim the 32 GB card and OOM. See [GPU Arbiter](#gpu-arbiter). |
-| `nvidia-gpu-tuning` (DaemonSet) | Privileged DaemonSet pinned to `nv-01` running `nvidia-smi -pm 1 -lgc 0,2800 -pl 550` to cap the RTX 5090's boost clock (stock max 3105 MHz; Xid 109 CTX SWITCH TIMEOUT mitigation) and board power (stock TDP 600 W → 550 W cap); re-asserted every 5 min. Consumes one of the 4 GPU time-slices to trigger CDI injection of `nvidia-smi`. |
+| --- | --- |
+| [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) | `gpu-operator` Helm chart (`v26.7.0`) with `driver` and `toolkit` disabled. On Talos the driver ships via the `nonfree-kmod-nvidia` system extension and the container toolkit via system extension + machine config, so the operator only runs NFD + device plugin. The single physical GPU is **time-sliced into 4 `nvidia.com/gpu` replicas**: one is held by the `nvidia-gpu-tuning` DaemonSet, the rest serve a session's Wolf sidecar + game container. vLLM consumes one replica when idle but is scaled to 0 during sessions (see [GPU Arbiter](#gpu-arbiter)). |
+| [Fenrir / direwolf-operator](https://github.com/games-on-whales/fenrir) | Operator (OCI HelmRelease) that reconciles `App`/`User`/`Session`/`Pairing` CRDs and creates session pods. Fronted by `moonlight-proxy`. Forked as `docker.io/shrinedogg/direwolf-operator:v0.1.0`. |
+| [Wolf](https://games-on-whales.github.io/wolf/) | Per-session streaming sidecar: Wayland compositor, GStreamer + NVENC video pipeline, PulseAudio capture, and virtual input. Forked as `docker.io/shrinedogg/wolf:v0.1.0` (wl_drm patch). |
+| [gpu-arbiter-operator](https://github.com/shrinedogg/gpu-arbiter-operator) (custom) | controller-runtime operator (`docker.io/shrinedogg/gpu-arbiter-operator:v0.1.1`) that reconciles a cluster-scoped `GPUArbiter` CR: scales the `vllm` Deployment to 0 whenever an `alex-steam`/`direwolf-worker` session pod appears in `dreamcast`, and back to 1 when idle, then lifts the `gpu.biggs.dog/await-vram` scheduling gate once VRAM is free. See [GPU Arbiter](#gpu-arbiter). |
+| `nvidia-gpu-tuning` (DaemonSet) | Privileged DaemonSet pinned to `nv-01` running `nvidia-smi -pm 1 -lgc 0,2800 -pl 550` to cap the RTX 5090 boost clock (stock max 3105 MHz; Xid 109 CTX SWITCH TIMEOUT mitigation) and board power (stock TDP 600 W -> 550 W cap); re-asserted every 5 min. Consumes one of the 4 GPU time-slices to trigger CDI injection of `nvidia-smi`. |
 
 ### GPU Arbiter
 
-The single 32 GB RTX 5090 can't host vLLM and a gaming session at once. The [`gpu-arbiter-operator`](https://github.com/shrinedogg/gpu-arbiter-operator) reconciles a cluster-scoped `GPUArbiter` CR (`cluster1`) and:
+The single 32 GB RTX 5090 cannot host vLLM and a gaming session at once. The [`gpu-arbiter-operator`](https://github.com/shrinedogg/gpu-arbiter-operator) reconciles a cluster-scoped `GPUArbiter` CR (`cluster1`) and:
 
 1. **Scales vLLM** to 0 when gaming pods appear, back to 1 when idle.
 2. **Lifts the scheduling gate** (`gpu.biggs.dog/await-vram`) once VRAM is freed.
 
-**Deployment:** `apps/dreamcast/gpu-arbiter-{operator,instance}`. Image: `shrinedogg/gpu-arbiter-operator:v0.1.1`. Query status with `kubectl get gpuarbiter cluster1`.
+**Deployment:** `clusters/cluster1/kubernetes/apps/dreamcast/gpu-arbiter-instance` and `gpu-arbiter-operator`. Image: `shrinedogg/gpu-arbiter-operator:v0.1.1`. Query status with `kubectl get gpuarbiter cluster1`.
 
 ### Defined Apps
 
-Three gaming apps under `fenrir/app/apps.yaml`: **Firefox** (reference), **Test Ball** (synthetic videotestsrc), **Steam** (Big Picture + persistent `/home/retro` PVC + DLSS). See [NOTES.md](docs/NOTES.md#dreamcast-engineering-notes) for details.
+Three gaming apps under `fenrir/app/apps.yaml`: **Firefox** (reference app), **Test Ball** (synthetic videotestsrc), **Steam** (Big Picture + persistent 250Gi `/home/retro` PVC + DLSS). See [NOTES.md](docs/NOTES.md#dreamcast-engineering-notes) for details.
 
 ### Forked Images
 
 See [NOTES.md](docs/NOTES.md#forked-images) for the list of patched Dreamcast images (direwolf-operator, moonlight-proxy, wolf-agent, wolf, gpu-arbiter-operator) and why they diverge from upstream.
 
-## 🤖 AI & Agents  (`cluster1`)
+## AI and Agents
 
 The `ai-system` namespace runs a fully local, GPU-accelerated agentic-ops stack: an OpenAI-compatible LLM served in-cluster by [vLLM](https://github.com/vllm-project/vllm), and [kagent](https://kagent.dev/) agents that use it to inspect and troubleshoot the cluster over MCP. No inference leaves the cluster. Per-task agent routing for this repo is documented in [`.rules`](.rules).
 
 ### Components
 
 | Component | Description |
-| --------- | ----------- |
-|[vLLM](https://github.com/vllm-project/vllm) | OpenAI-compatible inference server (`v0.26.0`, CUDA 12.9 for Blackwell) pinned to `nv-01`, consuming one of the RTX 5090's 4 `nvidia.com/gpu` time-slices. Scaled to 0 during [Dreamcast](#-dreamcast-game-streaming-stack) gaming sessions by the [GPU Arbiter](#gpu-arbiter) and back to 1 when idle. Serves [`rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm`](https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm) (served as `qwen36-local`) — a **27B dense** model with a Gated-DeltaNet / gated-attention hybrid (only 16 of 64 layers keep paged KV), NVFP4 via compressed-tensors (~18 GiB resident on the 32 GB card), **192K context** (`--max-model-len=196608`; native max 262K). fp8 KV cache, `--max-num-seqs 16`, `--max-num-batched-tokens 8192`, `--gpu-memory-utilization 0.95`, `--tool-call-parser qwen3_coder` + `--reasoning-parser qwen3`, `--language-model-only` (skips the vision encoder), prefix caching enabled. The 192K cap (raised from 131K) was driven by `exa-agent` search results (~38 KB each) overflowing 131K session windows. |
-| [kagent](https://kagent.dev/) | Agent framework + controller. Renders a `ModelConfig` (`qwen36-local` → local vLLM) and exposes an MCP server over a LAN-only HTTPRoute (`kagent-mcp` at `https://mcp.biggs.dog/mcp` on the internal LAN-only gateway `internal-biggs-dog`, VIP 192.168.6.15, TLS via the wildcard cert) plus a UI (`kagent.biggs.dog`) behind OAuth2 Proxy forward-auth. Backed by CNPG Postgres with pgvector for long-term (cross-session) vector memory. Embedding model: `BAAI/bge-m3` (via the `embeddings` service, CPU-only Infinity deployment). |
-| **Substrate runtime** (kagent ATE / actor runtime) | A control plane for **sandboxed agent code execution via gVisor**, deployed in `ai-system` (upstream hard-codes `ate-system`, so several namespace overrides are patched in). Components: `ate-controller`, `ate-api-server` (runs a forked image `shrinedogg/ateapi` carrying a JWT-JWKS-url patch), `atelet` worker DaemonSet, and `atenet-router`. gVisor `runsc` (`20260622.0`) is staged in the rustfs `ate-snapshots` bucket and pre-cached per node via a `runsc-cache` DaemonSet (the atelet's S3 client doesn't honor `AWS_ENDPOINT_URL`, so it can't pull from rustfs directly). A `WorkerPool` (`kagent-default`, `sandboxClass: gvisor`, `ateom-gvisor:v0.0.10`) is created by the kagent chart. The controller/atenet/atelet/ateom images are at upstream `v0.0.10`; the `ate-api-server` fork must track the same base (`v0.0.10-jwksurl`, pinned by digest) — a version skew silently breaks the golden-actor wire protocol (e.g. a v0.0.7 fork makes `CreateAtespace` return `Unimplemented`; a v0.0.9 fork vs a v0.0.10 ateom surfaces as a cryptic `"string field contains invalid UTF-8"` unmarshal error), pinning the 5 SandboxAgents at `Ready=ActorTemplateNotReady`. The old atelet-namespace patch is no longer needed: v0.0.9 upstreamed it as `installdefaults.NamespaceFromPodEnv()` (reads `POD_NAMESPACE`). Defined in `apps/ai-system/substrate/` + `substrate-crds/`. |
-| flux-mcp / `flux-agent` | A custom (non-chart) **read-only** kagent `Agent` wired to the Flux Operator MCP server, for GitOps inspection and reconciliation root-cause analysis. Defined in `apps/ai-system/flux-mcp/`. Per-agent memory disabled to avoid saturating the context window with large tool schemas. |
-| victoria-metrics-mcp / `vm-agent` | A custom kagent `Agent` backed by the [VictoriaMetrics MCP server](https://github.com/VictoriaMetrics/mcp-victoriametrics) (`v1.20.2`): PromQL/MetricsQL query access, alerting rule inspection, TSDB cardinality analysis, embedded VM docs. Defined in `apps/ai-system/victoria-metrics-mcp/`. |
-| exa-mcp / `exa-agent` | A custom kagent `Agent` backed by the [Exa MCP server](https://github.com/shrinedogg/exa-mcp-server) (`3.2.1`): web search, code discovery, company research (`web_search_exa`, `web_fetch_exa`, `web_search_advanced_exa`). Defined in `apps/ai-system/exa-mcp/`. Requires an Exa API key. Long-term memory **enabled** (with context compaction at 80K tokens); the 192K vLLM cap is what keeps large Exa result sets from overflowing. |
-| codebase-memory-mcp / `codebase-agent` | A custom kagent `Agent` backed by a [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) server (`v0.9.0`): structural code intelligence (tree-sitter → SQLite knowledge graph + bundled semantic search) over indexed repos — currently the **biggs.dog** repo itself, auto-synced from `main` via a git-sync native sidecar. The upstream image is stdio-only, so the pod wraps it in an `mcp-proxy` stdio→streamable-HTTP bridge (glibc binary staged into the musl bridge image via an initContainer). Defined in `apps/ai-system/codebase-memory-mcp/`. |
-| mindwtr-mcp / `mindwtr-agent` | A custom kagent `Declarative` Agent backed by the Mindwtr MCP server (`mindwtr-mcp`): GTD task management with full CRUD access to the Mindwtr SQLite database. Tools include task creation, inbox processing (2-minute rule), project management, weekly reviews, and focus checks. Runs with `executeCodeBlocks` enabled for Python runtime, 30-day vector memory, and context compaction at 80K tokens. Defined in `apps/ai-system/mindwtr-mcp/`. |
-| [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) | SIG-Apps `Sandbox` CRD + controller (`agents.x-k8s.io`, pinned to upstream `v0.5.0`, `controller.extensions: true`). Provides isolated, stateful single-pod runtimes for classic `kind: Agent` CRs that opt into `executeCodeBlocks` (code execution). Defined in `apps/ai-system/agent-sandbox/`. |
-| embeddings | CPU-only Infinity embedding server serving `BAAI/bge-m3` for kagent's long-term vector memory. Intentionally CPU-only to avoid contending with the GPU-constrained vLLM. Defined in `apps/ai-system/embeddings/`. |
+| --- | --- |
+| [vLLM](https://github.com/vllm-project/vllm) | OpenAI-compatible inference server (`docker.io/vllm/vllm-openai:v0.28.0`, CUDA 12.9 for Blackwell) pinned to `nv-01`, consuming one of the RTX 5090's 4 `nvidia.com/gpu` time-slices. Scaled to 0 during [Dreamcast](#dreamcast-game-streaming-stack) sessions by the [GPU Arbiter](#gpu-arbiter) and back to 1 when idle. Serves [`unsloth/Qwen3.8-27B-NVFP4`](https://huggingface.co/unsloth/Qwen3.8-27B-NVFP4) (served as `qwen 3.8 - local`) - a **27B dense** model with a Gated-DeltaNet / gated-attention hybrid (only 16 of 64 layers keep paged KV), NVFP4 via compressed-tensors (~19.9 GB on disk / ~18 GiB resident on the 32 GB card). **173K context** served (`--max-model-len=177184`; measured ceiling with 5.71 GiB available fp8 KV cache). fp8 KV cache, `--max-num-seqs 8`, `--max-cudagraph-capture-size 8`, `--max-num-batched-tokens 8192`, `--gpu-memory-utilization 0.96`, `--tool-call-parser qwen3_coder` + `--reasoning-parser qwen3`, `--enable-auto-tool-choice`, `--enable-prefix-caching`, `--trust-remote-code`, `--language-model-only` (skips the vision encoder). |
+| [kagent](https://kagent.dev/) | Agent framework and controller (chart `0.9.12`). Configured with ModelConfig `qwen 3.8 - local` -> local vLLM. Exposes an MCP server over a LAN-only HTTPRoute (`kagent-mcp` at `https://mcp.biggs.dog/mcp` on the internal gateway `internal-biggs-dog`, VIP 192.168.6.15) plus a UI (`kagent.biggs.dog`) behind OAuth2 Proxy forward-auth. Backed by CNPG Postgres with pgvector for long-term vector memory. Embedding model: `BAAI/bge-m3` via the `embeddings` service (CPU-only Infinity deployment). |
+| **Substrate runtime** (kagent ATE / actor runtime) | Control plane for **sandboxed agent code execution via gVisor**, deployed in `ai-system` (charts `substrate` and `substrate-crds` at `0.0.21`). Components: `ate-controller`, `ate-api-server` (digest-pinned fork `shrinedogg/ateapi@sha256:78d90103f3054bf6544bf3726fa63800a47b970b3425a3e60f4efbfff9bbdad3` with `--client-jwt-jwks-url`), `atelet` worker DaemonSet, and `atenet-router`. gVisor `runsc` (`20260622.0`) staged in rustfs `ate-snapshots` bucket and pre-cached per node via `runsc-cache` DaemonSet. A `WorkerPool` (`kagent-default`, `sandboxClass: gvisor`, `ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.21`) is managed by kagent. Postgres and rustfs storage are patched to `host-path`. `ate-system` namespace manifest included for chart RBAC. |
+| flux-mcp / `flux-agent` | Custom read-only kagent `Agent` wired to the Flux Operator MCP server for GitOps inspection and reconciliation root-cause analysis (`clusters/cluster1/kubernetes/apps/ai-system/flux-mcp/`). Per-agent memory disabled to avoid saturating context with tool schemas. |
+| victoria-metrics-mcp / `vm-agent` | Custom kagent `Agent` backed by the VictoriaMetrics MCP server (`v1.20.2`): PromQL/MetricsQL query access, alerting rule inspection, TSDB cardinality analysis (`clusters/cluster1/kubernetes/apps/ai-system/victoria-metrics-mcp/`). |
+| exa-mcp / `exa-agent` | Custom kagent `Agent` backed by the Exa MCP server (`3.2.1`): web search, code discovery, company research (`clusters/cluster1/kubernetes/apps/ai-system/exa-mcp/`). Long-term memory enabled with context compaction at 80K tokens. |
+| codebase-memory-mcp / `codebase-agent` | Custom kagent `Agent` backed by codebase-memory-mcp (`v0.9.0`): structural code intelligence over indexed repos (biggs.dog), auto-synced via git-sync sidecar. stdio-only upstream wrapped in `mcp-proxy` bridge (`clusters/cluster1/kubernetes/apps/ai-system/codebase-memory-mcp/`). |
+| mindwtr-mcp / `mindwtr-agent` | Custom kagent `Declarative` Agent backed by the Mindwtr MCP server (`mindwtr-mcp`): GTD task management with CRUD access to the Mindwtr SQLite database. Runs with `executeCodeBlocks` enabled, 30-day vector memory, and context compaction at 80K tokens (`clusters/cluster1/kubernetes/apps/ai-system/mindwtr-mcp/`). |
+| [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) | SIG-Apps `Sandbox` CRD + controller (`agents.x-k8s.io`, GitRepository ref `v1.0.0`, `controller.extensions: true`). Provides isolated, stateful single-pod runtimes for classic `kind: Agent` CRs that opt into `executeCodeBlocks`. |
+| embeddings | CPU-only Infinity embedding server serving `BAAI/bge-m3` for kagent's long-term vector memory. CPU-only to avoid contending with GPU-constrained vLLM. |
 
 **Available agents** (`kubectl get agents,sandboxagents -n ai-system`):
 
-The 11 agents split across **two deployment patterns**:
+The 11 agents split across two deployment patterns:
 
-- **Classic `kind: Agent` CRs** (invocable now via MCP): `flux-agent`, `vm-agent`, `exa-agent`, `cilium-debug-agent`, `cilium-policy-agent`, `codebase-agent`, `mindwtr-agent`. The two cilium agents are re-defined statically in `apps/ai-system/kagent/cilium-agents/` (disabled in the chart) so they carry generic `k8s_*` tools alongside Cilium tools; `codebase-agent` lives with its server in `apps/ai-system/codebase-memory-mcp/`.
-- **`kind: SandboxAgent` CRs on the substrate runtime** (`apps/ai-system/kagent/substrate-agents/`): `k8s-agent`, `helm-agent`, `promql-agent`, `observability-agent`, `cilium-manager-agent`. These are `READY=True` with golden actors built, but are **not yet invocable via the MCP server** — an upstream kagent limitation (`MCPHandler.listReadyAgents` lists only `v1alpha2.Agent` and hard-codes reason `DeploymentReady`, while substrate agents report `WorkloadReady`). Use the fallbacks in [`.rules`](.rules) / direct `kubectl` until kagent wires `SandboxAgent` → A2A.
-- **Disabled chart agents**: `argo-rollouts-agent`, `istio-agent`, `kgateway-agent` (plus the 5 substrate agents and 2 cilium agents are disabled in the chart so they don't double-render as classic `Agent` CRs).
+- **Classic `kind: Agent` CRs** (invocable via MCP): `flux-agent`, `vm-agent`, `exa-agent`, `cilium-debug-agent`, `cilium-policy-agent`, `codebase-agent`, `mindwtr-agent`. The two cilium agents are defined statically in `clusters/cluster1/kubernetes/apps/ai-system/kagent/cilium-agents/` with generic `k8s_*` tools alongside Cilium tools. `codebase-agent` lives in `clusters/cluster1/kubernetes/apps/ai-system/codebase-memory-mcp/`.
+- **`kind: SandboxAgent` CRs on the substrate runtime** (`clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/`): `k8s-agent`, `helm-agent`, `promql-agent`, `observability-agent`, `cilium-manager-agent`. These are `READY=True` with golden actors built, but are not yet invocable via the MCP server due to an upstream kagent limitation (`listReadyAgents` lists only `v1alpha2.Agent` with `DeploymentReady`, while substrate agents report `WorkloadReady`). Use the fallbacks in [`.rules`](.rules) or direct `kubectl`.
+- **Disabled chart agents**: `argo-rollouts-agent`, `istio-agent`, `kgateway-agent` (the 5 substrate agents and 2 cilium agents are disabled in chart values to prevent duplicate classic Agent CRs).
 
-See [`.rules`](.rules) for agent selection by task domain and the live invocability status.
+See [`.rules`](.rules) for agent selection by task domain and live invocability status.
 
-## 🌐 Networking Configuration
+## Networking Configuration
 
-### BGP Peering  (`cluster1`)
+### BGP Peering (`cluster1`)
 
-`cluster1` uses Cilium BGP to peer with the UDM router (ASN 64563, `192.168.1.1`) from Cilium's ASN 64564, advertising LoadBalancer IPs from the pool `192.168.6.6–254` (deliberately off-subnet from the nodes on `192.168.2.0/24`, so VIPs route via the UDM). This allows in-cluster services to advertise VIPs to the LAN. k8s-gateway has **fallthrough enabled** with NextDNS resolvers (`45.90.28.232` / `45.90.30.232`) so unknown `biggs.dog` names resolve to public DNS — this is how LAN/VPN clients reach cluster0 services (omni/netbird/dex at `87.58.147.51`). The default k8s-gateway forward plugin (`/etc/resolv.conf`) was replaced to avoid a DNS loop with in-cluster CoreDNS. See [NOTES.md](docs/NOTES.md#networking-stack) for details on the full networking stack (Cilium, k8s-gateway, CoreDNS, Gateway API).
+`cluster1` uses Cilium BGP to peer with the UDM router (ASN 64563, `192.168.1.1`) from Cilium ASN 64564, advertising LoadBalancer IPs from the pool `192.168.6.6-254` (off-subnet from the nodes on `192.168.2.0/24`, so VIPs route via the UDM). k8s-gateway has **fallthrough enabled** with NextDNS resolvers (`45.90.28.232` / `45.90.30.232`) so external `biggs.dog` names resolve to public DNS. Before fallthrough, a local hosts block resolves `omni.biggs.dog`, `dex.biggs.dog`, and `factory.biggs.dog` to `192.168.2.31` (the cluster0 node), preventing Cloudflare 403 challenge pages on gRPC calls. See [NOTES.md](docs/NOTES.md#networking-stack) for details.
 
-### Edge Ingress  (`cluster0`)
+### Management Ingress (`cluster0`)
 
-`cluster0` advertises its single WAN IP (`87.58.147.51/32`) via a Cilium L2 announcement policy (no BGP — it's a single cloud node). Public DNS for `omni`/`dex`/`netbird`/`*.biggs.dog` resolves through Cloudflare to the `cluster0-gateway`; per-host TLS certs are issued in the `networking` namespace by the `letsencrypt-prod` ClusterIssuer (DNS-01/Cloudflare). UDP STUN (NetBird `3478`) bypasses the cloud LB via `externalIPs`.
+`cluster0` advertises its node IP (`192.168.2.31/32`) via a Cilium L2 announcement policy shared with `omni-siderolink`. `cluster0-gateway` provides TLS termination for `omni.biggs.dog`, `dex.biggs.dog`, and `factory.biggs.dog` via certificates issued by the `letsencrypt-prod` ClusterIssuer.
 
-## 🔐 Secret Management
+## Secret Management
 
-Secrets follow a three-tier model (on both clusters):
+Secrets follow a three-tier model:
 
-1. **SOPS with age encryption** — Git-committed secrets (Cilium policies, app defaults, and the 1Password Connect credentials/token). The repo-wide age key was rotated on 2026-07-04; `sops.yaml` lists the deployed key plus a pre-staged next key.
-2. **External Secrets + 1Password** — Runtime secrets from 1Password vaults (API keys, credentials) via 1Password Connect (`connect` chart `v2.4.1` on both clusters).
-3. **cert-manager** — Automatic certificate issuance + renewal (ACME Let's Encrypt, CA issuer).
+1. **SOPS with age encryption** - Git-committed secrets (Cilium policies, app defaults, and 1Password Connect credentials/token). Configured in `.sops.yaml`.
+2. **External Secrets + 1Password** - Runtime secrets from 1Password vaults via 1Password Connect (`connect` chart `v2.4.1` on both clusters).
+3. **cert-manager** - Automatic certificate issuance and renewal (ACME Let's Encrypt, CA issuer).
 
 See [NOTES.md](docs/NOTES.md#security-model) for details.
 
-## 🚀 Getting Started
+## Getting Started
 
 ### Prerequisites
 
@@ -300,23 +307,23 @@ See [NOTES.md](docs/NOTES.md#security-model) for details.
 
 ### Bootstrap
 
-Each cluster bootstraps via its own Flux Operator syncing from:
+Each cluster bootstraps via Flux Operator syncing from:
 
 ```
 https://github.com/shrinedogg/biggs.dog.git
 ```
 
-- `cluster0` syncs `clusters/cluster0` (edge/mgmt).
-- `cluster1` syncs `clusters/cluster1` (workloads).
+- `cluster0` bootstraps via `knr-bootstrap local-talos` using `bootstrap.toml` syncing `clusters/cluster0/capi`, then widens to `clusters/cluster0`.
+- `cluster1` is managed by self-hosted Omni on `cluster0` and syncs `clusters/cluster1`.
 
-Flux automatically reconciles each cluster's state based on the manifests in its path. Secrets are decrypted by SOPS (age key) before Flux applies them.
+Flux automatically reconciles desired state based on manifests in each path. Secrets are decrypted by SOPS (age key) before Flux applies them.
 
-## 🔁 Dependency Updates
+## Dependency Updates
 
-Dependency updates are managed by Renovate using the repository config in `renovate.json`.
-It is set up to update Flux `HelmRelease` chart versions (HelmRepository and OCI-based sources) and container images referenced in Kubernetes manifests, including the media stack under `clusters/cluster1/kubernetes/apps/media/`.
+Dependency updates are managed by Renovate using the repository config in `renovate.json` (`ghcr.io/mend/renovate-ce:15.4.0`).
+It updates Flux `HelmRelease` chart versions (HelmRepository and OCI-based sources) and container images referenced in Kubernetes manifests, including the media stack under `clusters/cluster1/kubernetes/apps/media/`.
 
-## 📁 App Structure Pattern
+## App Structure Pattern
 
 Each application follows a consistent pattern:
 
@@ -330,6 +337,6 @@ Each application follows a consistent pattern:
         └── helmrelease.yaml (or raw manifests)
 ```
 
-## 📝 License
+## License
 
-Personal homelab configuration - feel free to use as reference.
+Personal homelab configuration. Feel free to use as reference.

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -2,19 +2,19 @@
 
 This document contains detailed architectural decisions, engineering notes, and historical context that is less critical for operators but helpful for maintainers and contributors.
 
-> **Two clusters (migration in progress).** The homelab is split across `cluster0` — a single-node **UpCloud cloud** edge/mgmt cluster (public WAN `87.58.147.51`, Cilium L2 announcement) running Dex, NetBird, Omni, Talos Image Factory, cert-manager, external-secrets, and CiliumNetworkPolicies (two-tier: apps + infra) — and `cluster1` — the **on-prem 6-node bare-metal** workload cluster (Cilium BGP → UDM, `192.168.6.0/24` VIPs) running all applications, storage, GPU/AI, and observability. Flux pruning is disabled on both during the cutover. Most sections below describe `cluster1` workloads; cluster-specific notes are called out inline.
+> **Two clusters.** The homelab is split across `cluster0` (an on-prem single-node **Talos management cluster** at LAN IP `192.168.2.31`, running Cilium with L2 announcement) hosting Dex, Omni, Talos Image Factory, cert-manager, external-secrets, OpenEBS, CAPI management subtree, and CiliumNetworkPolicies (two-tier: apps + infra); and `cluster1` (the **on-prem 6-node bare-metal** workload cluster running Cilium BGP -> UDM, with `192.168.6.0/24` VIPs) hosting all applications, storage, GPU/AI, and observability. Remote administration uses the UDM built-in VPN (NetBird has been retired). Flux pruning is disabled on both root syncs as a safety measure. Most sections below describe `cluster1` workloads; cluster-specific notes are called out inline.
 >
-> **Note**: `cluster1` node specs (Talos Linux version, Kubernetes version, OS versions) in `README.md` are managed via Omni and reflect state at time of documentation. For live cluster versions, use `kubectl version` and check the Omni console (now run in-cluster on `cluster0` — see [System & Hardware](#system--hardware)). This Git repo drives desired state for workloads, not node OS versions.
+> **Note**: `cluster1` node specs (Talos Linux version, Kubernetes version, OS versions) in `README.md` are managed via Omni and reflect state at time of documentation. For live cluster versions, use `kubectl version` and check the Omni console (run in-cluster on `cluster0` at `omni.biggs.dog` - see [System and Hardware](#system-and-hardware)). This Git repo drives desired state for workloads, not node OS versions.
 
 ## Dreamcast Engineering Notes
 
 ### Forked Images
 
-Getting the GPU-accelerated game streaming stack working end-to-end required forking the Games on Whales operator (`[shrinedogg/fenrir](https://github.com/shrinedogg/fenrir)`) plus several cluster-specific config decisions. Images are built locally and published to Docker Hub with semver tags.
+Getting the GPU-accelerated game streaming stack working end-to-end required forking the Games on Whales operator ([shrinedogg/fenrir](https://github.com/shrinedogg/fenrir)) plus several cluster-specific config decisions. Images are built locally and published to Docker Hub with semver tags.
 
 | Image | Tag | Reason |
 | ----- | --- | ------ |
-| `docker.io/shrinedogg/direwolf-operator` | `v0.1.0` | Retries stream reconciliation (upstream stalls the session until the 1-minute reaper kills it whenever the agent isn't up on the first try) and prunes stale `trackedSessions` entries that spam logs. |
+| `docker.io/shrinedogg/direwolf-operator` | `v0.1.0` | Retries stream reconciliation (upstream stalls the session until the 1-minute reaper kills it whenever the agent is not up on the first try) and prunes stale `trackedSessions` entries that spam logs. |
 | `docker.io/shrinedogg/moonlight-proxy` | `v0.1.1` | Raises the `/launch` wait from 25s to 120s; a cold start (image pull + Wolf boot + agent readiness) exceeds 25s, so upstream returned 500 and the client cancelled the session. |
 | `docker.io/shrinedogg/wolf-agent` | `v0.1.0` | Implements Wolf's `fake-udev` mechanism in Go: on device hotplug it writes `/run/udev/data` entries and broadcasts synthetic libudev netlink events in the pod netns so SDL/Steam detect controllers. |
 | `docker.io/shrinedogg/wolf` | `v0.1.0` | Overlay on `wolf:stable` with a patched `gst-wayland-display` ([shrinedogg/gst-wayland-display](https://github.com/shrinedogg/gst-wayland-display), branch `fix/optional-wl-drm`): skips the legacy `wl_drm` global when dmabuf v4 feedback is active, fixing the wlroots/Sway nested-compositor abort. |
@@ -22,7 +22,7 @@ Getting the GPU-accelerated game streaming stack working end-to-end required for
 
 ### Defined Apps Detail
 
-**Firebase** (reference app)
+**Firefox** (reference app)
 - Validates the GPU/video path end-to-end with a real browser workload.
 
 **Test Ball** (synthetic testing)
@@ -35,135 +35,134 @@ Getting the GPU-accelerated game streaming stack working end-to-end required for
 - Persistent 250Gi `host-path` PVC at `/home/retro` survives session restarts, storing login, library, and installed games.
 - DLSS support under Proton (via NVIDIA wine NGX bridge DLLs restored in a separate 4Gi `nvngx-cache` PVC).
 
-### GPU Time-Slicing & vLLM
+### GPU Time-Slicing and vLLM
 
 The single RTX 5090 (32 GB) is sliced into **4 `nvidia.com/gpu` replicas**:
 1. One held by `nvidia-gpu-tuning` DaemonSet (caps boost clock to mitigate Xid 109 errors).
-2. One reserved for vLLM when idle (consuming ~31 GB, leaving only ~1 GB free).
+2. One reserved for vLLM when idle (consuming ~22-30 GB, leaving minimal free VRAM).
 3. Two for the session's Wolf sidecar + game container.
 
 When a gaming pod spins up, the `gpu-arbiter-operator` scales vLLM to 0, freeing its slice so the session has two slices available (up to 8 GB per game pod).
 
-### DCGM Metrics & Gate Lifting
+### DCGM Metrics and Gate Lifting
 
 The `gpu-arbiter-operator` removes the `gpu.biggs.dog/await-vram` scheduling gate via a three-condition precedent:
 
-1. **vLLM down** (~1–2s latency) — the primary signal.
-2. **Free VRAM threshold** (`DCGM_FI_DEV_FB_FREE` via VictoriaMetrics, ~30s lag) — the secondary signal.
-3. **Safety timeout** (`spec.timeoutSeconds`, default 45s) — fallback if metrics are stale or missing.
+1. **vLLM down** (~1-2s latency) - the primary signal.
+2. **Free VRAM threshold** (`DCGM_FI_DEV_FB_FREE` via VictoriaMetrics, ~30s lag) - the secondary signal.
+3. **Safety timeout** (`spec.timeoutSeconds`, default 45s) - fallback if metrics are stale or missing.
 
-If any condition holds, the gate lifts and the pod can schedule. This degrades gracefully: even if DCGM exporter stalls or metrics lag, the session won't hang indefinitely.
+If any condition holds, the gate lifts and the pod can schedule. This degrades gracefully: even if DCGM exporter stalls or metrics lag, the session will not hang indefinitely.
 
 ### Dreamcast on Kubernetes: Implementation Notes
 
 Getting the full stack running required several insights:
 
-- **LB IP sharing** — the operator's `--lb-sharing-key` is aligned to `direwolf` so Cilium LB-IPAM hands every per-session RTP Service the same external IP as the proxy. Mismatched keys split the IP and the RTSP handshake times out (macOS errno 60).
-- **GPU on the app container** — the game container needs its own `nvidia.com/gpu` request; CDI driver/device injection is per-allocated-container, so without it the app has no render node and produces a black stream.
-- **GPU time-multiplexing with vLLM (`gpu-arbiter`)** — the 32 GB RTX 5090 can't hold both a gaming session and vLLM (~31 GB at idle) at once. Scaling now uses the `deployments/scale` subresource; a backwards `client.MergeFrom` previously emitted `{"spec":{"replicas":null}}`, deleting the field so it defaulted back to `1` and vLLM never actually scaled down; and (2) status is written with a full `Status().Update()` rather than a JSON merge patch, so zero-valued `omitempty` fields like `gamePods` clear instead of going stale.
-- **`GBM_BACKENDS_PATH`** — set on both the Wolf sidecar and the Steam container; the CDI hook drops the NVIDIA GBM backend in `/usr/local/lib/gbm` while Mesa only searches `/usr/lib/x86_64-linux-gnu/gbm`.
-- **Patched Wolf compositor (wl_drm fix)** — Wolf's `gst-wayland-display` advertised both the legacy `wl_drm` global and `zwp_linux_dmabuf_v1` v4 feedback; nested wlroots (Sway 0.19+) binds both and aborts on the duplicate device announcement (`assert(wl->drm_render_name == NULL)`). The patched `shrinedogg/wolf` image skips `wl_drm` when dmabuf v4 feedback is active (legacy clients can opt back in with `GST_WAYLAND_DISPLAY_ADVERTISE_WL_DRM=1`). This was needed to try Sway as the compositor; the Steam app now runs under Gamescope instead, but the patch stays deployed so Sway remains a working option (and Gamescope's Wayland client path is unaffected either way).
-- **Gamescope device pinning (`--prefer-vk-device`)** — nv-01's Ryzen 7800X3D exposes an AMD iGPU (RADV `RAPHAEL_MENDOCINO`, PCI `1002:164e`, `/dev/dri/renderD128`) alongside the RTX 5090 (PCI `10de:2b85`, `/dev/dri/renderD129`). The Steam container is privileged (for `uinput` hotplug, see below), so it sees both GPUs; Gamescope enumerates Vulkan devices and selects the AMD iGPU, then aborts at `CVulkanTexture::BInit` (`rendervulkan.cpp:2195`, assertion `modifiers.size() > 0`) because the iGPU can't provide the dmabuf modifiers it needs. `GAMESCOPE_MODE` (default `-b` in the GOW `launch-comp.sh`, interpolated unquoted so it word-splits into args) is set to `-b --prefer-vk-device 10de:2b85` to force gamescope onto the dGPU. (Wolf's capture is unaffected — it's pinned via `wolfConfig.runtimeVariables.renderNode: /dev/dri/renderD129`.)
-- **`/dev/shm` sizing** — a 4Gi memory-backed `emptyDir` at `/dev/shm`; the 64Mi runtime default exhausts instantly under Steam's CEF UI, yielding a black screen with only a cursor.
-- **User namespaces** — Steam's pressure-vessel runtime requires `user.max_user_namespaces`, which Talos defaults to `0`. Enabled cluster-wide via Omni machine-config patches on every node (node-level config, not in this repo); also used by the `auth` workload, which runs with `hostUsers: false` so its containers' root maps to an unprivileged host UID.
-- **Privileged Steam container** — Wolf hotplugs `uinput` devices mid-session; Kubernetes has no equivalent of Docker's `device_cgroup_rules`, so the container must be privileged to open the late-appearing `/dev/input/event`* nodes.
-- **Root Wolf entrypoint** — a ConfigMap (`wolf-entrypoint.yaml`) shadows the GOW `/entrypoint.sh` to force the Wolf sidecar to run as root, avoiding the upstream `gosu`/`supervisord` privilege-drop crash loop. (Re-declaring `PUID`/`PGID`/`UNAME` is rejected by server-side apply as duplicate map keys.)
-- **DRM render-node override** — `wolfConfig.runtimeVariables.renderNode` is pinned to `/dev/dri/renderD129`. The NVIDIA container toolkit injects the dGPU with its host numbering (`renderD128` doesn't exist inside the container), and with the wrong node Wolf fails GPU vendor detection and silently falls back to **software x264 encoding**.
-- **In-container `udevd` (Steam Input)** — beyond the `wolf-agent` fake-udev (which surfaces the Moonlight controller), the Steam app runs a real `systemd-udevd` + `udevadm trigger`. Steam Input emulates a *second* uinput pad for the game, and without an in-container udevd nothing writes its udev db entry / libudev event, so SDL/Proton see no controller in-game.
-- **Focus guard (Sway only, currently dormant)** — a small Python/Xlib watcher (`focus-guard.py`) in the Steam container. Steam's `steamwebhelper` maps an invisible, class-less notification popup that steals X input focus from the running game; Gamescope pins focus to the game (so the guard is unnecessary under the current Gamescope config), but Sway honors the grab, breaking keyboard + Steam Input routing. The guard returns focus to the viewable `steam_app_*` window whenever an unnamed/class-less window holds it (legitimate Big Picture focus changes are left alone). It's gated on `if [ "$RUN_SWAY" = "true" ]`, so under Gamescope the script is written but never launched.
-- **PulseAudio device names** — the Steam app deliberately does **not** export `PULSE_SINK`/`PULSE_SOURCE`. The image has no `pactl`, so the upstream lookup exported empty/bogus names; libpulse treats a set-but-invalid device as an explicit request and fails the stream (silent Steam) instead of falling back to Wolf's default virtual sink.
-- **No `NVIDIA_DRIVER_CAPABILITIES` on the app container** — the operator already appends `NVIDIA_DRIVER_CAPABILITIES=all` to the app container (`session.go`); re-declaring it makes the server-side-apply patch invalid (duplicate map key) so the Deployment is never created and the reaper kills the session after 60s. (Same failure class as the root-entrypoint `PUID` note above.)
-- **DLSS / NVAPI under Proton** — DLSS needs two things on Talos. (1) The `nonfree-kmod-nvidia` extension strips the NVIDIA "wine" NGX bridge DLLs (`nvngx.dll` / `_nvngx.dll`), so an `nvngx-bridge` initContainer extracts them from the matching driver `.run` and caches them on the `nvngx-cache` host-path PVC (downloaded at most once); Proton copies them into each prefix's `system32` when `PROTON_ENABLE_NVAPI=1`. (2) DLSS is gated behind NVAPI, so `PROTON_ENABLE_NVAPI=1` + `DXVK_ENABLE_NVAPI=1` are set on the Steam container, otherwise the in-game DLSS toggle stays greyed out despite the RTX GPU.
+- **LB IP sharing** - the operator's `--lb-sharing-key` is aligned to `direwolf` so Cilium LB-IPAM hands every per-session RTP Service the same external IP as the proxy. Mismatched keys split the IP and the RTSP handshake times out (macOS errno 60).
+- **GPU on the app container** - the game container needs its own `nvidia.com/gpu` request; CDI driver/device injection is per-allocated-container, so without it the app has no render node and produces a black stream.
+- **GPU time-multiplexing with vLLM (`gpu-arbiter`)** - the 32 GB RTX 5090 cannot hold both a gaming session and vLLM at once. Scaling now uses the `deployments/scale` subresource; a backwards `client.MergeFrom` previously emitted `{"spec":{"replicas":null}}`, deleting the field so it defaulted back to `1` and vLLM never actually scaled down; and (2) status is written with a full `Status().Update()` rather than a JSON merge patch, so zero-valued `omitempty` fields like `gamePods` clear instead of going stale.
+- **`GBM_BACKENDS_PATH`** - set on both the Wolf sidecar and the Steam container; the CDI hook drops the NVIDIA GBM backend in `/usr/local/lib/gbm` while Mesa only searches `/usr/lib/x86_64-linux-gnu/gbm`.
+- **Patched Wolf compositor (wl_drm fix)** - Wolf's `gst-wayland-display` advertised both the legacy `wl_drm` global and `zwp_linux_dmabuf_v1` v4 feedback; nested wlroots (Sway 0.19+) binds both and aborts on the duplicate device announcement (`assert(wl->drm_render_name == NULL)`). The patched `shrinedogg/wolf` image skips `wl_drm` when dmabuf v4 feedback is active (legacy clients can opt back in with `GST_WAYLAND_DISPLAY_ADVERTISE_WL_DRM=1`). This was needed to try Sway as the compositor; the Steam app now runs under Gamescope instead, but the patch stays deployed so Sway remains a working option (and Gamescope's Wayland client path is unaffected either way).
+- **Gamescope device pinning (`--prefer-vk-device`)** - nv-01's Ryzen 7800X3D exposes an AMD iGPU (RADV `RAPHAEL_MENDOCINO`, PCI `1002:164e`, `/dev/dri/renderD128`) alongside the RTX 5090 (PCI `10de:2b85`, `/dev/dri/renderD129`). The Steam container is privileged (for `uinput` hotplug, see below), so it sees both GPUs; Gamescope enumerates Vulkan devices and selects the AMD iGPU, then aborts at `CVulkanTexture::BInit` (`rendervulkan.cpp:2195`, assertion `modifiers.size() > 0`) because the iGPU cannot provide the dmabuf modifiers it needs. `GAMESCOPE_MODE` (default `-b` in the GOW `launch-comp.sh`, interpolated unquoted so it word-splits into args) is set to `-b --prefer-vk-device 10de:2b85` to force gamescope onto the dGPU. (Wolf's capture is unaffected; it is pinned via `wolfConfig.runtimeVariables.renderNode: /dev/dri/renderD129`.)
+- **`/dev/shm` sizing** - a 4Gi memory-backed `emptyDir` at `/dev/shm`; the 64Mi runtime default exhausts instantly under Steam's CEF UI, yielding a black screen with only a cursor.
+- **User namespaces** - Steam's pressure-vessel runtime requires `user.max_user_namespaces`, which Talos defaults to `0`. Enabled cluster-wide via Omni machine-config patches on every node (node-level config, not in this repo); also used by the `auth` workload, which runs with `hostUsers: false` so its containers' root maps to an unprivileged host UID.
+- **Privileged Steam container** - Wolf hotplugs `uinput` devices mid-session; Kubernetes has no equivalent of Docker's `device_cgroup_rules`, so the container must be privileged to open the late-appearing `/dev/input/event`* nodes.
+- **Root Wolf entrypoint** - a ConfigMap (`wolf-entrypoint.yaml`) shadows the GOW `/entrypoint.sh` to force the Wolf sidecar to run as root, avoiding the upstream `gosu`/`supervisord` privilege-drop crash loop. (Re-declaring `PUID`/`PGID`/`UNAME` is rejected by server-side apply as duplicate map keys.)
+- **DRM render-node override** - `wolfConfig.runtimeVariables.renderNode` is pinned to `/dev/dri/renderD129`. The NVIDIA container toolkit injects the dGPU with its host numbering (`renderD128` does not exist inside the container), and with the wrong node Wolf fails GPU vendor detection and silently falls back to software x264 encoding.
+- **In-container `udevd` (Steam Input)** - beyond the `wolf-agent` fake-udev (which surfaces the Moonlight controller), the Steam app runs a real `systemd-udevd` + `udevadm trigger`. Steam Input emulates a second uinput pad for the game, and without an in-container udevd nothing writes its udev db entry / libudev event, so SDL/Proton see no controller in-game.
+- **Focus guard (Sway only, currently dormant)** - a small Python/Xlib watcher (`focus-guard.py`) in the Steam container. Steam's `steamwebhelper` maps an invisible, class-less notification popup that steals X input focus from the running game; Gamescope pins focus to the game (so the guard is unnecessary under the current Gamescope config), but Sway honors the grab, breaking keyboard + Steam Input routing. The guard returns focus to the viewable `steam_app_*` window whenever an unnamed/class-less window holds it (legitimate Big Picture focus changes are left alone). It is gated on `if [ "$RUN_SWAY" = "true" ]`, so under Gamescope the script is written but never launched.
+- **PulseAudio device names** - the Steam app deliberately does **not** export `PULSE_SINK`/`PULSE_SOURCE`. The image has no `pactl`, so the upstream lookup exported empty/bogus names; libpulse treats a set-but-invalid device as an explicit request and fails the stream (silent Steam) instead of falling back to Wolf's default virtual sink.
+- **No `NVIDIA_DRIVER_CAPABILITIES` on the app container** - the operator already appends `NVIDIA_DRIVER_CAPABILITIES=all` to the app container (`session.go`); re-declaring it makes the server-side-apply patch invalid (duplicate map key) so the Deployment is never created and the reaper kills the session after 60s. (Same failure class as the root-entrypoint `PUID` note above.)
+- **DLSS / NVAPI under Proton** - DLSS needs two things on Talos. (1) The `nonfree-kmod-nvidia` extension strips the NVIDIA "wine" NGX bridge DLLs (`nvngx.dll` / `_nvngx.dll`), so an `nvngx-bridge` initContainer extracts them from the matching driver `.run` and caches them on the `nvngx-cache` host-path PVC (downloaded at most once); Proton copies them into each prefix's `system32` when `PROTON_ENABLE_NVAPI=1`. (2) DLSS is gated behind NVAPI, so `PROTON_ENABLE_NVAPI=1` + `DXVK_ENABLE_NVAPI=1` are set on the Steam container, otherwise the in-game DLSS toggle stays greyed out despite the RTX GPU.
 
 ## Core Components Detail
 
 ### Networking Stack
 
-Both clusters run **Cilium** as the CNI (replaces kube-proxy) and **Gateway API** with **AgentGateway** (OCI HelmRelease, charts pinned to a known-good alpha build `0.0.0-alpha.a655af15`), but they advertise service VIPs differently:
+Both clusters run **Cilium** as the CNI (replaces kube-proxy) and **Gateway API** with **AgentGateway** (OCI HelmRelease, charts pinned to a verified build), but they advertise service VIPs differently:
 
-- **`cluster1` (on-prem)** — Cilium **BGP** peers with the UDM router (local ASN 64564 ↔ peer 64563 @ `192.168.1.1`), advertising the `192.168.6.6–254` pool (off-subnet from the nodes on `192.168.2.0/24`, so VIPs route via the UDM).
-- **`cluster0` (cloud)** — single-node, so it uses a Cilium **L2 announcement** policy with a single-IP pool (`87.58.147.51/32`). The UpCloud Managed LB only supports TCP/HTTP (no UDP), so UDP services (NetBird STUN `3478`) are exposed via `externalIPs` bound on the node's NIC instead of a LoadBalancer Service.
+- **`cluster1` (on-prem workloads)** - Cilium **BGP** peers with the UDM router (local ASN 64564 <-> peer 64563 at `192.168.1.1`), advertising the `192.168.6.6-254` pool (off-subnet from the nodes on `192.168.2.0/24`, so VIPs route via the UDM).
+- **`cluster0` (on-prem management)** - single-node, so it uses a Cilium **L2 announcement** policy with a single-IP pool (`192.168.2.31/32`), shared across `cluster0-gateway` and `omni-siderolink` via the `cluster0-edge` sharing key.
 
 `cluster1` split-horizon DNS:
-- **k8s-gateway** — authoritative for `*.biggs.dog` (LB `192.168.6.6`, ClusterIP `10.105.74.41`); resolves internal gateway VIPs in-cluster and external gateway VIPs for LAN clients.
-- **CoreDNS** (Talos-managed `kube-dns`) conditionally forwards `biggs.dog` queries to k8s-gateway's ClusterIP instead of Cloudflare, keeping pod traffic in-cluster.
-- **lan-dns** — LAN CoreDNS resolver (LB `192.168.6.16`) forwards `biggs.dog` → k8s-gateway and everything else → NextDNS over DoT.
+- **k8s-gateway** - authoritative for `*.biggs.dog` (LB `192.168.6.6`, ClusterIP `10.101.183.97`, 2 replicas); resolves internal gateway VIPs in-cluster and external gateway VIPs for LAN clients.
+- **CoreDNS** (Talos-managed `kube-dns`) conditionally forwards `biggs.dog` queries to k8s-gateway's ClusterIP (`10.101.183.97`) instead of Cloudflare, keeping pod traffic in-cluster.
+- **lan-dns** - LAN CoreDNS resolver (LB `192.168.6.16`) forwards `biggs.dog` -> k8s-gateway and everything else -> NextDNS over DoT (`tls://45.90.28.0`, `tls://45.90.30.0`).
 
-`cluster0` public ingress is the `cluster0-gateway` (`networking` ns) with HTTPS listeners for `omni`/`dex`/`netbird.biggs.dog`, each backed by a per-host cert issued **in the `networking` namespace** (Gateway API resolves name-only `certificateRefs` to the gateway's own namespace) via the `letsencrypt-prod` ClusterIssuer (DNS-01/Cloudflare).
+`cluster0` ingress is `cluster0-gateway` (`networking` namespace) with HTTPS listeners for `omni.biggs.dog`, `dex.biggs.dog`, and `factory.biggs.dog`, each backed by a per-host cert issued in the `networking` namespace (Gateway API resolves name-only `certificateRefs` to the gateway's own namespace) via the `letsencrypt-prod` ClusterIssuer (DNS-01/Cloudflare). Omni re-encrypts to its pod cert over HTTPS.
 
-**k8s-gateway fallthrough:** `cluster1`'s k8s-gateway has **fallthrough enabled** with NextDNS resolvers (`45.90.28.232` / `45.90.30.232`) so unknown `biggs.dog` names resolve to public DNS — this is how LAN/VPN clients reach cluster0 services (omni/netbird/dex at `87.58.147.51`). The chart's default `forward . /etc/resolv.conf` plugin was replaced because it loops: k8s-gateway → `/etc/resolv.conf` → in-cluster CoreDNS → k8s-gateway again (CoreDNS conditionally forwards `biggs.dog` to k8s-gateway's ClusterIP), resulting in SERVFAIL. The fix replicates the full chart default plugin list with only the forward parameters changed to NextDNS IPs. The `ready`/`health`/`prometheus` plugins must stay for liveness/readiness probes and ServiceMonitor.
+**k8s-gateway fallthrough:** `cluster1`'s k8s-gateway has **fallthrough enabled** with NextDNS resolvers (`45.90.28.232` / `45.90.30.232`) so unknown `biggs.dog` names resolve to public DNS. Before fallthrough, both `k8s-gateway` and `lan-dns` carry a `hosts` block mapping `omni.biggs.dog`, `dex.biggs.dog`, and `factory.biggs.dog` to `192.168.2.31` locally: public DNS for these is Cloudflare-proxied, and the Cloudflare edge answers gRPC with a 403 challenge page that breaks omnictl and Omni-proxied kubeconfigs from the LAN. The chart's default `forward . /etc/resolv.conf` plugin was replaced because it loops: k8s-gateway -> `/etc/resolv.conf` -> in-cluster CoreDNS -> k8s-gateway again (CoreDNS conditionally forwards `biggs.dog` to k8s-gateway's ClusterIP), resulting in SERVFAIL. The fix replicates the full chart default plugin list with only the forward parameters changed to NextDNS IPs. The `ready`/`health`/`prometheus` plugins remain for liveness/readiness probes and ServiceMonitor.
 
-**NetBird gRPC** — NetBird multiplexes gRPC over HTTP/2 on port 80; the gateway must speak HTTP/2 to the backend, not HTTP/1.1. AgentGateway ignores the `agentgateway.dev/backend-protocol: h2c` annotation on HTTPRoute, so an `AgentgatewayPolicy` (`netbird-grpc`) is used instead, targeting the `netbird-grpc` HTTPRoute and setting `backend.http.version: HTTP2`.
-
-**Omni BackendTLSPolicy** — Omni serves its own HTTPS (the omni binary runs with `--cert/--key` on `:443` with a Let's Encrypt cert for `omni.biggs.dog`). The cluster0-gateway terminates client TLS at the omni-https listener, then must re-encrypt to omni-ui over HTTPS. The HTTPRoute annotation `agentgateway.dev/backend-protocol: "HTTPS"` declares that intent, but agentgateway only actually speaks TLS to the backend when a `BackendTLSPolicy` tells it what hostname/SNI to use and what CA to trust. Without this policy, agentgateway sent plain HTTP to omni-ui:443 → omni's TLS server rejected it (`Client sent an HTTP request to an HTTPS server`). The policy uses `wellKnownCACertificates: System` (trusts the public CA that signed omni's Let's Encrypt cert — ISRG Root X1) and `hostname: omni.biggs.dog`.
+**Omni BackendTLSPolicy** - Omni serves its own HTTPS (the omni binary runs with `--cert/--key` on `:443` with a Let's Encrypt cert for `omni.biggs.dog`). The cluster0-gateway terminates client TLS at the omni-https listener, then must re-encrypt to omni-ui over HTTPS. The HTTPRoute annotation `agentgateway.dev/backend-protocol: "HTTPS"` declares that intent, but agentgateway only actually speaks TLS to the backend when a `BackendTLSPolicy` tells it what hostname/SNI to use and what CA to trust. Without this policy, agentgateway sent plain HTTP to omni-ui:443 -> omni's TLS server rejected it (`Client sent an HTTP request to an HTTPS server`). The policy uses `wellKnownCACertificates: System` (trusts the public CA that signed omni's Let's Encrypt cert - ISRG Root X1) and `hostname: omni.biggs.dog`.
 
 ### Storage Layers
 
-- **Rook-Ceph** — distributed block storage (`ceph-block` StorageClass, pool `ceph-blockpool` size 3) on four OSDs, one Micron 7450 960 GB NVMe per worker. Rook v1.20 no longer deploys CSI itself: the `Driver`/`OperatorConfig` CRs for the ceph-csi-operator live in `rook-ceph/csi-rbac/drivers.yaml` next to the driver RBAC; without them no provisioner or nodeplugin runs. OSD devices are named by `/dev/disk/by-id/nvme-Micron_7450_..._<serial>`, never `/dev/nvmeXn1` (see Pitfalls, Storage). Cluster fsid `37a406cf-68c2-4131-96e7-f7b7c050b2c4` survived the 2026-09-07 rebuild via the mon-store adoption procedure in `.omni/cluster1/` (plan `2026-09-07_000000-cluster1-rebuild-selfhosted-omni-ceph-preserved`).
-- **OpenEBS** — local container-attached storage (ZFS and local disk).
-- **Volsync** — bidirectional backup and replication of PVs (e.g., game data, media libraries).
-- **NFS CSI** — NFS provisioner for shared namespaces.
-- **ZFS** — volume management on nodes with ZFS pools.
+- **Rook-Ceph** - distributed block storage (`ceph-block` StorageClass, pool `ceph-blockpool` size 3) on four OSDs, one Micron 7450 960 GB NVMe per worker. Rook v1.20 (chart `v1.20.6`) no longer deploys CSI itself: the `Driver`/`OperatorConfig` CRs for the ceph-csi-operator live in `rook-ceph/csi-rbac/drivers.yaml` next to the driver RBAC; without them no provisioner or nodeplugin runs. OSD devices are named by `/dev/disk/by-id/nvme-Micron_7450_..._<serial>`, never `/dev/nvmeXn1` (see Storage pitfalls). Cluster fsid `37a406cf-68c2-4131-96e7-f7b7c050b2c4` survived the 2026-09-07 rebuild via the mon-store adoption procedure in `.omni/cluster1/` (plan `2026-09-07_000000-cluster1-rebuild-selfhosted-omni-ceph-preserved`).
+- **OpenEBS** - local container-attached storage (ZFS and local disk via localpv host-path provisioner, chart `4.6.0` on both clusters).
+- **Volsync** - bidirectional backup and replication of PVs (chart `0.16.0`) to Backblaze B2. Cache PVCs pinned to `ceph-block`.
+- **Snapshot Controller** - CSI volume snapshots (chart `5.2.0`).
+- **NFS CSI** - NFS provisioner for shared namespaces (chart `4.13.4`).
+- **ZFS** - volume management on nodes with ZFS pools.
 
-### Database & Caching
+### Database and Caching
 
-- **CNPG** — PostgreSQL operator managing the Postgres cluster (used by Pocket ID, kagent, and others).
-- **Barman Cloud** — CNPG plugin for backup/recovery to object storage.
-- **Dragonfly** — Redis-compatible in-memory store (used by OAuth2 Proxy for session storage and other services).
+- **CNPG** - PostgreSQL operator managing in-cluster Postgres clusters (chart `0.29.0`, used by Pocket ID, kagent, and others; PG18 minimal Trixie image catalog).
+- **Barman Cloud** - CNPG plugin (`0.7.1`) for backup/recovery to object storage.
+- **Dragonfly** - Redis-compatible in-memory store (used by OAuth2 Proxy for session storage and other services).
 
 ### Security Model
 
 Secrets follow a three-tier model:
 
-1. **SOPS + age** — Git-encrypted secrets (for config that can be committed, e.g., Cilium policies, app defaults).
-2. **External Secrets + 1Password** — Runtime secrets synced from 1Password vaults (for API keys, credentials).
-3. **cert-manager** — Automatic certificate issuance and renewal (ACME Let's Encrypt, CA issuer for self-signed).
+1. **SOPS + age** - Git-encrypted secrets (for config that can be committed, e.g., Cilium policies, app defaults).
+2. **External Secrets + 1Password** - Runtime secrets synced from 1Password vaults (chart `2.9.0` with 1Password Connect chart `v2.4.1`).
+3. **cert-manager** - Automatic certificate issuance and renewal (chart `v1.21.1`, ACME Let's Encrypt, CA issuer for self-signed).
 
 ### Mindwtr (Notes App)
 
 Mindwtr (`mindwtr` namespace) is a self-hosted, offline-capable notes PWA (`mindwtr-app`, static nginx build) paired with a sync/REST server (`mindwtr-cloud`) that stores a single JSON store + attachments on an RWO PVC (`strategy: Recreate`, since only one writer can hold the store). Both are fronted by a single `mindwtr.biggs.dog` HTTPRoute on the LAN-only `internal-biggs-dog` gateway, path-split three ways:
 
-- `/health` and `/v1` route straight to `mindwtr-cloud` and are **bearer-token only** (`MINDWTR_CLOUD_AUTH_TOKENS`, from the `mindwtr-cloud-auth` ExternalSecret) — upstream Mindwtr's mobile/desktop/CLI clients can't complete an interactive OIDC login, so this path deliberately bypasses SSO.
-- `/` (the PWA, named rule `pwa`) is fronted by a Pocket-ID-backed `AgentgatewayPolicy` (`mindwtr-forward-auth`) that targets the HTTPRoute by `sectionName: pwa`, so only the browser path gets the shared `.biggs.dog` oauth2-proxy cookie SSO — the API rules are untouched.
+- `/health` and `/v1` route straight to `mindwtr-cloud` and are **bearer-token only** (`MINDWTR_CLOUD_AUTH_TOKENS`, from the `mindwtr-cloud-auth` ExternalSecret); upstream Mindwtr's mobile/desktop/CLI clients cannot complete an interactive OIDC login, so this path deliberately bypasses SSO.
+- `/` (the PWA, named rule `pwa`) is fronted by a Pocket-ID-backed `AgentgatewayPolicy` (`mindwtr-forward-auth`) that targets the HTTPRoute by `sectionName: pwa`, so only the browser path gets the shared `.biggs.dog` oauth2-proxy cookie SSO; the API rules are untouched.
 
 `mindwtr-cloud` trusts `X-Forwarded-For` from the pod CIDR (`MINDWTR_CLOUD_TRUST_PROXY_HEADERS`/`_TRUSTED_PROXY_IPS`) since agentgateway is the only ingress path under Cilium default-deny, so its auth-failure rate limiter sees real client IPs instead of bucketing everything against the gateway address.
 
-### Network Policies & Cilium Configuration
+### Network Policies and Cilium Configuration
 
 The cluster enforces least-privilege **CiliumNetworkPolicy** across all namespaces. Policies are split into two independent Flux Kustomizations:
 
-- **`network-policies-apps`** — lower-risk application namespaces (auth, biggs, dragonfly, games, jitsi, matrix, media, renovate on cluster1; auth, netbird, omni on cluster0). Can be updated with confidence.
-- **`network-policies-infra`** — higher-risk infrastructure namespaces (networking, ai-system, cnpg-system, observability, rook-ceph, kube-system on cluster1; networking, cert-manager, external-secrets, flux-system on cluster0). Can be suspended independently with `flux suspend kustomization network-policies-infra` if edge or control plane regresses.
+- **`network-policies-apps`** - application namespaces (auth, biggs, dragonfly, dreamcast, games, livekit, matrix, media, mindwtr, renovate on cluster1; auth, omni on cluster0). Can be updated with confidence.
+- **`network-policies-infra`** - infrastructure namespaces (networking, ai-system, cnpg-system, observability, rook-ceph, kube-system on cluster1; capi, cert-manager, external-secrets, flux-system, networking on cluster0). Can be suspended independently with `flux suspend kustomization network-policies-infra` if edge or control plane regresses.
 
 This two-tier approach allows staged rollouts and rapid rollback without affecting application policies.
 
 **Key Cilium policy conventions** (each is documented inline in the policy files):
 
-- **Default-deny is implicit.** Cilium rejects an empty deny-all (`ingress: [] / egress: []` → `VALID: False`), so there is no standalone deny-all policy. Every namespace's `allow-*` policies select `endpointSelector: {}`, which puts all pods into default-deny for any traffic not explicitly allowed.
+- **Default-deny is implicit.** Cilium rejects an empty deny-all (`ingress: [] / egress: []` -> `VALID: False`), so there is no standalone deny-all policy. Every namespace's `allow-*` policies select `endpointSelector: {}`, which puts all pods into default-deny for any traffic not explicitly allowed.
 - **L7 DNS on every `allow-egress-dns`.** A bare L3/L4 DNS allow lets Go resolvers' rapid parallel A/AAAA replies miss the egress conntrack entry and get dropped as new ingress. Routing DNS through the Cilium DNS proxy (`rules.dns: matchPattern "*"`) fixes that and enables `toFQDNs` (used for GitHub, the OIDC issuer, Backblaze B2, etc.).
 - **ClusterIP service return paths.** With `bpf-lb` + default-deny ingress, replies from a ClusterIP service (e.g. CNPG `-rw` Postgres) arrive reverse-NAT'd from the service VIP and miss conntrack, so DB clients carry an explicit `allow-ingress-from-postgres` return-path rule.
-- **Gateway data planes** are selected by `gateway.networking.k8s.io/gateway-class-name: agentgateway` (one Deployment per Gateway, e.g. `wildcard-biggs-dog`) — distinct from the control-plane `agentgateway` pod — so `*.biggs.dog` ingress and backend forwarding are authorized.
-- **Internet pulls hide behind caches.** Default-deny egress silently breaks anything that reaches out only occasionally — e.g. vLLM downloads a *new* model from Hugging Face but loads already-cached ones from its PVC, so blocked egress only surfaces on a model swap. Such components (`allow-egress-vllm-huggingface`, renovate's `allow-egress-https`, volsync→Backblaze B2) carry an explicit egress allow, scoped to the pod and kept broad on `:443` where the upstream uses rotating CDN/Xet hosts with no stable FQDN set.
+- **Gateway data planes** are selected by `gateway.networking.k8s.io/gateway-class-name: agentgateway` (one Deployment per Gateway, e.g. `wildcard-biggs-dog`) - distinct from the control-plane `agentgateway` pod - so `*.biggs.dog` ingress and backend forwarding are authorized.
+- **Internet pulls hide behind caches.** Default-deny egress silently breaks anything that reaches out only occasionally; e.g. vLLM downloads a new model from Hugging Face but loads already-cached ones from its PVC, so blocked egress only surfaces on a model swap. Such components (`allow-egress-vllm-huggingface`, renovate's `allow-egress-https`, volsync->Backblaze B2) carry an explicit egress allow, scoped to the pod and kept broad on `:443` where the upstream uses rotating CDN/Xet hosts with no stable FQDN set.
 
-### Identity & SSO Details
+### Identity and SSO Details
 
-The two clusters run **different identity stacks** (a deliberate split: the edge cluster needs a always-on cloud IdP reachable before any on-prem dependency is up; the on-prem workload cluster uses the passkey-first stack for its apps).
+The two clusters run different identity stacks (a deliberate split: the management cluster needs an always-on IdP reachable before any on-prem dependency is up; the workload cluster uses the passkey-first stack for its apps).
 
-**Dex** (`cluster0`, `dex.biggs.dog`) — the root OIDC IdP for the edge plane:
-- `ghcr.io/dexidp/dex:v2.45.1`, stateless (`storage.type: memory`, single replica; tokens don't survive restarts, fine for interactive logins).
+**Dex** (`cluster0`, `dex.biggs.dog`) - root OIDC IdP for the management plane:
+- `ghcr.io/dexidp/dex:v2.45.1`, stateless (`storage.type: memory`, single replica; tokens do not survive restarts, fine for interactive logins).
 - `enablePasswordDB: true` with a static admin user; clients/secrets templated into the config from 1Password.
-- Static clients: `omni` (Omni OIDC login), `netbird` (NetBird's embedded IdP upstream connector), `image-factory` (Image Factory UI).
-- **Omni's OIDC callback** — the actual callback path is `/oidc/consume` (not the previously-guessed `/Callback` or `/callback`). The earlier mismatch caused Dex `bad request` errors.
-- **Image Factory** — the Image Factory UI at `factory.biggs.dog` uses an `oauth2-proxy` (v7.6.0) authenticated against Dex. The proxy upstreams to `image-factory.omni.svc.cluster.local:8080`. The HTTPRoute path-splits: API paths go directly to image-factory, UI paths (`/` and `/oauth2/*`) go through the proxy.
-- `connectors: []` — Dex is the root IdP here, not a federator in front of Pocket ID.
+- Static clients: `omni` (Omni OIDC login), `image-factory` (Image Factory UI).
+- **Omni's OIDC callback** - the actual callback path is `/oidc/consume` (not `/Callback` or `/callback`).
+- **Image Factory** - the Image Factory UI at `factory.biggs.dog` uses an `oauth2-proxy` authenticated against Dex. The proxy upstreams to `image-factory.omni.svc.cluster.local:8080`. The HTTPRoute path-splits: API paths go directly to image-factory, UI paths (`/` and `/oauth2/*`) go through the proxy.
+- `connectors: []` - Dex is the root IdP here, not a federator in front of Pocket ID.
 
-**Pocket ID** (`cluster1`, `id.biggs.dog`) — passkey-first OIDC for workload apps:
-- Passkey-first OIDC provider (FIDO2 WebAuthn).
+**Pocket ID** (`cluster1`, `id.biggs.dog`) - passkey-first OIDC for workload apps:
+- Passkey-first OIDC provider (`v2.14.0`, FIDO2 WebAuthn).
 - Postgres backend via CNPG (user database, secret storage).
 - File uploads stored in the same database.
 
 **OAuth2 Proxy** (`cluster1`, `auth.biggs.dog`):
-- OIDC client to Pocket ID.
+- OIDC client to Pocket ID (image `v7.15.4`, chart `10.7.0`).
 - Provides forward-auth for browser apps (agentgateway `AgentgatewayPolicy` with `traffic.extAuth`).
 - Uses **Dragonfly (Redis)** for session storage (small session ticket instead of large cookie).
 - Protected apps attach a `ReferenceGrant` to reach the OAuth2 Proxy service in the `auth` namespace.
@@ -172,173 +171,155 @@ The two clusters run **different identity stacks** (a deliberate split: the edge
 - Rook-Ceph dashboard
 - Bookboss
 - kagent UI
-- Mindwtr PWA (browser rule only, targeted by `sectionName` — the `/v1` sync + REST API rules stay bearer-token-only; see [Mindwtr](#mindwtr-notes-app))
+- Mindwtr PWA (browser rule only, targeted by `sectionName`; the `/v1` sync + REST API rules stay bearer-token-only - see [Mindwtr](#mindwtr-notes-app))
 
 **Native OIDC apps (`cluster1`):**
 - Grafana (direct Pocket ID client, no forward-auth needed)
 
 ### Observability Stack
 
-- **VictoriaMetrics** — metrics storage (time-series database optimized for Prometheus protocol).
-- **Victoria Logs** — log aggregation and storage.
-- **Grafana Operator** — Grafana deployment and dashboard management (dashboards stored as CRDs).
+- **VictoriaMetrics** - metrics storage (`victoria-metrics-k8s-stack` chart `0.91.2`).
+- **VictoriaLogs** - log aggregation and storage (chart `0.13.9` single, `0.3.7` collector).
+- **Grafana Operator** - Grafana deployment and dashboard management (chart `10.5.15`, dashboards stored as CRDs).
 
 The DCGM exporter (NVIDIA GPU metrics) feeds into VictoriaMetrics, and the `gpu-arbiter-operator` queries it via the VictoriaMetrics HTTP API.
 
-### System & Hardware
+### System and Hardware
 
-- **NFD** (Node Feature Discovery) — detects hardware capabilities (GPU models, CPU flags, etc.) and labels nodes.
-- **Intel GPU Plugin** — enables Intel iGPU device plugin for media transcoding on worker nodes.
-- **NVIDIA GPU Operator** — device plugin with time-slicing (driver/toolkit provided by Talos system extensions, not by the operator).
-- **Omni (Sidero)** — now run **in-cluster on `cluster0`** (`apps/omni/`, image `ghcr.io/siderolabs/omni:v1.9.1`) as the full Talos management plane (UI at `omni.biggs.dog`, machine API `:8090`, event sink `:8091`, K8s proxy `:8100`, Siderolink WireGuard `:50180/udp` advertised at `87.58.147.51:50180`). Since 2026-09-07 it is the **sole manager of `cluster1`** (rebuilt from maintenance mode into this instance with Ceph data preserved; the hosted Sidero SaaS Omni is retired). Node join is via the generic ISO from `factory.biggs.dog` (control-01 needs the `control-01-bond` media preset because its switch ports are a static LACP aggregate). Machine templates and per-machine patches: `.omni/cluster1/self-hosted/` (git-ignored, `omnictl cluster template sync -f cluster-template.yaml`). LAN clients must resolve `omni.biggs.dog` to `192.168.2.31`: both `k8s-gateway` and `lan-dns` carry a `hosts` block for the four cluster0 edge names because the Cloudflare-proxied public answer 403s gRPC. The on-prem `cluster1` nodes phone home over Siderolink. Runs privileged with `/dev/net/tun`; double-TLS via `BackendTLSPolicy` (see below). Backed by embedded etcd + SQLite PVCs; OIDC login via Dex.
-- **Talos Image Factory** — builds and signs custom Talos Linux images with cosign (`ghcr.io/siderolabs/image-factory:v1.3.3`). Stateless HTTP service on `:8080` behind an `oauth2-proxy` (v7.6.0) authenticated against Dex at `factory.biggs.dog`. Durable state lives in a registry PVC. cosign signing key and public key are mounted as Secrets. Rate-limit policy and an embedded OCI registry (`registry-deployment`) are also deployed.
-- **Per-machine Omni `ConfigPatch`es** — node-level config still lives in Omni as per-machine `ConfigPatch`es (each node carries a `10-<machine-id>` user patch: hostname, NIC rings, node-specific tweaks). Local copies live under `omni/` (git-ignored, outside `clusters/` so Flux never reconciles them). Inspect/apply with `omnictl` (`omnictl get configpatch`, `omnictl apply -f ...`). Nodes imported from existing Talos clusters got this auto-generated on import; machines scaled directly from Omni did not, so their equivalent settings must be authored by hand. CoreDNS is configured cluster-wide via the `coredns-custom` inline-manifest patch (scoped to the cluster, not per node). When setting an explicit `HostnameConfig.hostname` on a directly-scaled node, also `$patch: delete` the default `auto` field, or Talos rejects the config (`'auto' and 'hostname' cannot be set at the same time`).
+- **NFD** (Node Feature Discovery) - detects hardware capabilities (GPU models, CPU flags, etc.) and labels nodes.
+- **Intel GPU Plugin** - enables Intel iGPU device plugin for media transcoding on worker nodes.
+- **NVIDIA GPU Operator** - device plugin with time-slicing (chart `v26.7.0`; driver and toolkit provided by Talos system extensions).
+- **Omni (Sidero)** - run in-cluster on `cluster0` (`apps/omni/`, image `ghcr.io/siderolabs/omni:v1.10.5`) as the full Talos management plane (UI at `omni.biggs.dog`, machine API `:8090`, event sink `:8091`, K8s proxy `:8100`, Siderolink WireGuard `:50180/udp` advertised at `192.168.2.31:50180`). Sole manager of `cluster1` (the hosted Sidero SaaS Omni is retired). Node join is via the generic ISO from `factory.biggs.dog` (control-01 needs the `control-01-bond` media preset because its switch ports are a static LACP aggregate). Machine templates and per-machine patches: `.omni/cluster1/self-hosted/` (git-ignored, `omnictl cluster template sync -f cluster-template.yaml`). LAN clients must resolve `omni.biggs.dog` to `192.168.2.31`: both `k8s-gateway` and `lan-dns` carry a `hosts` block for edge names because the Cloudflare-proxied public answer 403s gRPC. Runs privileged with `/dev/net/tun`; double-TLS via `BackendTLSPolicy`. Backed by embedded etcd + SQLite PVCs on OpenEBS; OIDC login via Dex.
+- **Talos Image Factory** - builds and signs custom Talos Linux images with cosign (`ghcr.io/siderolabs/image-factory:v1.6.0`). Stateless HTTP service on `:8080` behind an `oauth2-proxy` authenticated against Dex at `factory.biggs.dog`. Durable state lives in a registry PVC. cosign signing key and public key are mounted as Secrets. Rate-limit policy and an embedded OCI registry (`registry-deployment`) are also deployed.
+- **Cluster API (CAPI) on `cluster0`** - CAPI operator (`0.28.0`), core CAPI `v1.14`, CABPT `v0.7.6`, CACPPT `v0.6.4`, and CAPT `v0.7.1` (Tinkerbell) manage the management node. Manifests live in `clusters/cluster0/capi/`.
+- **Per-machine Omni `ConfigPatch`es** - node-level config lives in Omni as per-machine `ConfigPatch`es (each node carries a `10-<machine-id>` user patch: hostname, NIC rings, node-specific tweaks). Local copies live under `.omni/cluster1/self-hosted/` (git-ignored). Inspect/apply with `omnictl` (`omnictl get configpatch`, `omnictl apply -f ...`). CoreDNS is configured cluster-wide via the `coredns-custom` inline-manifest patch (scoped to the cluster, not per node). When setting an explicit `HostnameConfig.hostname` on a directly-scaled node, also `$patch: delete` the default `auto` field, or Talos rejects the config (`'auto' and 'hostname' cannot be set at the same time`).
 
 ### Automation
 
-- **Renovate** — automated dependency updates for HelmRelease chart versions and container images referenced in Kubernetes manifests. Configured in `renovate.json`.
+- **Renovate** - automated dependency updates for HelmRelease chart versions and container images referenced in Kubernetes manifests (`ghcr.io/mend/renovate-ce:15.4.0`). Configured in `renovate.json`.
 
-## AI & Agents Architecture
+## AI and Agents Architecture
 
 The `ai-system` namespace runs a fully local, GPU-accelerated agentic-ops stack. The vLLM and kagent infrastructure is shared; agent-specific configs are in [`.rules`](.rules).
 
 ### vLLM Deployment
 
-- **Model**: [`rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm`](https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm) (served as `qwen36-local`) — a **27B dense** model (all params active) with a **Gated-DeltaNet / gated-attention hybrid** (only 16 of 64 layers keep paged KV), NVFP4 via compressed-tensors (~18 GiB resident on the 32 GB card). **192K context** served (`--max-model-len=196608`; native max 262K).
-- **Version**: v0.23.0 (CUDA 12.9 for Blackwell GPU support on RTX 5090).
+- **Model**: [`unsloth/Qwen3.8-27B-NVFP4`](https://huggingface.co/unsloth/Qwen3.8-27B-NVFP4) (served as `qwen 3.8 - local`) - a **27B dense** model with a **Gated-DeltaNet / gated-attention hybrid** (only 16 of 64 layers keep paged KV), NVFP4 via compressed-tensors (~19.9 GB on disk / ~18 GiB resident on the 32 GB card). **173K context** served (`--max-model-len=177184`; native max 262K).
+- **Version**: `docker.io/vllm/vllm-openai:v0.28.0` (CUDA 12.9 for Blackwell GPU support on RTX 5090).
 - **GPU**: One of the RTX 5090's 4 time-slices; vLLM pins the bulk of the 32 GB card.
 - **Scaling**: Idle = 1 replica; gaming session = 0 replicas (managed by `gpu-arbiter-operator`).
 - **API**: OpenAI-compatible (`/v1/chat/completions`, etc.) at `http://vllm.ai-system.svc:8000`.
 
-### vLLM Configuration & Performance
+### vLLM Configuration and Performance
 
-**Context cap rationale**: The model's native max is 262K. It was long capped at 131K (to roughly double KV concurrency on the 32 GB card), but was **raised to 192K** (`--max-model-len=196608`) because `exa-agent` web-search results (~38 KB each) were overflowing 131K session windows (one session hit ~164K tokens). The Gated-DeltaNet hybrid keeps most layers' KV bounded, so even 192K is affordable.
+**Context cap rationale**: The model's native max is 262K. It is served at 173K (`--max-model-len=177184`) as vLLM's measured ceiling for this quant at util 0.96 (yielding 5.71 GiB available fp8 KV cache). The Gated-DeltaNet hybrid keeps most layers' KV bounded, ensuring long-context prompts remain performant.
 
-**Configuration details** (from `apps/ai-system/vllm/app/deployment.yaml`):
-- **`--max-model-len 196608` (192K)** — raised from 131K for exa-agent search-result headroom (see above).
-- **`--max-num-seqs 16` / `--max-cudagraph-capture-size 16`** (lowered from 32): the dense 27B model has far more active params per token than the prior MoE, so 16-way keeps prefill responsive under parallel kagent fan-out (the prior 32-way stall was on the MoE; this is a further stability margin).
-- **`--gpu-memory-utilization 0.95`** (raised from 0.90): the 27B dense NVFP4 quant is lighter on residency (~18 GiB), leaving headroom to grow the KV pool back toward the 192K cap.
-- **`--max-num-batched-tokens=8192`** (bumped from 4096): reduces prefill scheduling rounds for medium prompts.
+**Configuration details** (from `clusters/cluster1/kubernetes/apps/ai-system/vllm/app/deployment.yaml`):
+- **`--max-model-len 177184` (173K)** - measured ceiling providing headroom over large `exa-agent` sessions (~164K tokens).
+- **`--max-num-seqs 8` / `--max-cudagraph-capture-size 8`** - concurrency cap sized for the dense 27B model on 5.71 GiB KV cache (where one max-length prompt takes most of the pool).
+- **`--gpu-memory-utilization 0.96`** - documented ceiling leaving headroom for CUDA graph allocation. (Util 0.97 contributed to a node lockup when embeddings also ran on GPU).
+- **`--max-num-batched-tokens 8192`** - reduces prefill scheduling rounds for medium tool prompts.
 - **`--kv-cache-dtype fp8`**.
-- **Quantization**: auto-detected `compressed-tensors` NVFP4 from the checkpoint — **no `--quantization` flag** is passed (vLLM reads the model's NVFP4 config directly).
-- **Tool-call parser**: `--tool-call-parser qwen3_coder` + `--reasoning-parser qwen3` (with `--enable-auto-tool-choice`), paired with the model's built-in chat template. (The prior MoE used `qwen3_xml`; this quant recommends `qwen3_coder`.)
-- **`--language-model-only`** — skips the vision encoder on this multimodal checkpoint (replaces the old `--limit-mm-per-prompt`).
+- **Quantization**: auto-detected `compressed-tensors` NVFP4 from the checkpoint; no `--quantization` flag is passed.
+- **Tool-call parser**: `--tool-call-parser qwen3_coder` + `--reasoning-parser qwen3` (with `--enable-auto-tool-choice`), paired with the model's built-in chat template.
+- **`--language-model-only`** - skips the vision encoder on this checkpoint, preserving ~3 GB of VRAM for KV cache.
 - `--enable-prefix-caching`, `--trust-remote-code`.
 
-**Benchmark methodology** (`scripts/vllm-benchmark.py`):
-- Runs 8 prompt profiles (short query, short factual, medium conversation, medium analysis, long tool-context, long reasoning, very long conversation history, structured response) at configurable concurrency/warmup/repetitions via raw aiohttp SSE parsing (bypasses OpenAI client streaming bugs).
-- Results saved as JSON; compare with `scripts/compare-benchmarks.py`.
-- Synthetic workload benchmark simulates 8 kagent-style prompt profiles (50 → 4,000 prompt tokens, 80 → 500 gen tokens) at concurrency 4 with 3 rep/scenario.
-- **Measured performance** (measured on the prior MoE config; current dense 27B runs at `gpu-mem-util 0.95` / `max-num-seqs 16` / 192K):
-  - Median TTFT **~1.12s** (stddev 0.07s)
-  - Decode throughput **~186 tok/s** (stddev 10)
-  - Total request time **~2.44s** median
-  - Tail TTFT improved ~11% and decode stddev dropped ~29% vs baseline (fewer KV-preemptions, fewer prefill rounds)
-- **Raw `vllm bench serve` on the 5090** (prior MoE, at the then-served 131K context):
-  - Single-stream **~250 tok/s @ ~65 ms TTFT** (TPOT ~4 ms)
-  - Batched Aggregate **~2,450 tok/s @ 32-way** and **~3,070 tok/s @ 64-way** concurrency (0 failures)
-  - Well within the 32 GB card
-  - **Note:** these figures are from the prior model; `max-num-seqs` is now 16 for production stability (the dense model is compute-heavier per token), but the 64-way figure remains valid as a theoretical throughput ceiling for the card.
-
-**Model right-sizing (history)**: The cluster previously ran `NeuralNet-Hub/Qwen3.6-27B-NVFP4`, but per its author that was a suboptimal `llm-compressor` quant only validated on a **48 GB** card ([discussion](https://huggingface.co/NeuralNet-Hub/Qwen3.6-27B-NVFP4/discussions/1)) — it barely fit the 32 GB 5090 (util pinned near 0.984, 65K context max), causing OOM/`no cache blocks` churn and overflowing `flux-agent`'s ~64K tool schemas. An intermediate swap to the smaller, KV-efficient Gemma-4-26B-A4B (14B on disk, sliding-window attention, 256K context) resolved the OOM/context churn. A move to NVIDIA's official `nvidia/Qwen3.6-35B-A3B-NVFP4` (35B MoE, ~19B on disk, Mamba-hybrid, served at 131K) restored a stronger base with KV headroom.
-
-The **current** model is [`rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm`](https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm) — a **27B dense** NVFP4 quant. The prior `unsloth/Qwen3.6-27B-NVFP4` dense quant left the vision tower + embeddings in BF16 (~23 GiB resident), capping context at ~80K; this quant compresses those too (~18 GiB resident), restoring the full window **and** concurrency. Paired with a Gated-DeltaNet / gated-attention hybrid (only 16 of 64 layers keep paged KV) and `max-model-len` raised to 192K, it now fits `exa-agent`'s large search-result sessions alongside long-term memory with no overflow. See `apps/ai-system/vllm/app/deployment.yaml` for the in-tree rationale comments.
+**Model right-sizing (history)**:
+1. `NeuralNet-Hub/Qwen3.6-27B-NVFP4` (suboptimal `llm-compressor` quant validated only on 48 GB card; util pinned near 0.984, 65K context max, OOM / cache block starvation).
+2. `Gemma-4-26B-A4B` (14B on disk, sliding-window attention, 256K context; resolved OOM churn).
+3. `nvidia/Qwen3.6-35B-A3B-NVFP4` (35B MoE, ~19B on disk, Mamba-hybrid, served at 131K).
+4. `rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm` (27B dense, ~18 GiB resident, 192K context).
+5. `unsloth/Qwen3.6-27B-NVFP4` (dense quant with BF16 vision/embeddings, ~23 GiB resident, 177184 ceiling with 5.71 GiB KV).
+6. `unsloth/Qwen3.8-27B-NVFP4` (current: Unsloth Dynamic V3.0, ~19.9 GB disk / ~18 GiB resident, Gated-DeltaNet hybrid attention with only 16 of 64 layers keeping paged KV, 173K context at util 0.96 and 8-way concurrency).
 
 ### Embeddings Service
 
 - **Model**: `BAAI/bge-m3` (Infinity embedding server, CPU-only).
-- **Deployment**: `michaelf34/infinity:latest-cpu` with PyTorch backend (not ONNX).
+- **Deployment**: `michaelf34/infinity:latest-cpu` with PyTorch backend.
 - **Port**: 7997 (internal service).
 - **API**: OpenAI-compatible `/v1/embeddings` endpoint.
 - **Usage**: Backing kagent's long-term vector memory via the `embedding-model` ModelConfig.
-- **CPU-only by design**: The single GPU (nv-01) is fully committed to vLLM and scaled to 0 during gaming; a second GPU consumer would contend. Embedding traffic is infrequent and low-throughput, so CPU is sufficient.
+- **CPU-only by design**: The single GPU (`nv-01`) is committed to vLLM and scaled to 0 during gaming. Running embeddings on CPU avoids contention and prevents node memory pressure.
 
 ### kagent Agents
 
-The 11 agents split across **two deployment patterns** — classic `kind: Agent` CRs (the python runtime, each its own Deployment) and `kind: SandboxAgent` CRs on the substrate runtime (gVisor-sandboxed actors):
+The 11 agents split across two deployment patterns: classic `kind: Agent` CRs (python runtime, each its own Deployment) and `kind: SandboxAgent` CRs on the substrate runtime (gVisor-sandboxed actors):
 
-**Classic `kind: Agent` CRs** (invocable now via MCP) — the python runtime, each runs as its own Deployment:
-- `flux-agent` (read-only) — Flux GitOps inspection (custom, `apps/ai-system/flux-mcp/`).
-- `vm-agent` — VictoriaMetrics query + TSDB analysis (custom, `apps/ai-system/victoria-metrics-mcp/`).
-- `exa-agent` — Web search and research (custom, `apps/ai-system/exa-mcp/`).
-- `cilium-debug-agent` — Cilium diagnosis (static, `apps/ai-system/kagent/cilium-agents/`; carries generic `k8s_*` tools).
-- `cilium-policy-agent` — Cilium policy authoring (static, `apps/ai-system/kagent/cilium-agents/`; carries generic `k8s_*` tools).
-- `codebase-agent` — Structural code intelligence over indexed repos (custom, `apps/ai-system/codebase-memory-mcp/`).
+**Classic `kind: Agent` CRs** (invocable via MCP) - python runtime, each runs as its own Deployment:
+- `flux-agent` (read-only) - Flux GitOps inspection (custom, `clusters/cluster1/kubernetes/apps/ai-system/flux-mcp/`).
+- `vm-agent` - VictoriaMetrics query + TSDB analysis (custom, `clusters/cluster1/kubernetes/apps/ai-system/victoria-metrics-mcp/`).
+- `exa-agent` - Web search and research (custom, `clusters/cluster1/kubernetes/apps/ai-system/exa-mcp/`).
+- `cilium-debug-agent` - Cilium diagnosis (static, `clusters/cluster1/kubernetes/apps/ai-system/kagent/cilium-agents/`; carries generic `k8s_*` tools).
+- `cilium-policy-agent` - Cilium policy authoring (static, `clusters/cluster1/kubernetes/apps/ai-system/kagent/cilium-agents/`; carries generic `k8s_*` tools).
+- `codebase-agent` - Structural code intelligence over indexed repos (custom, `clusters/cluster1/kubernetes/apps/ai-system/codebase-memory-mcp/`).
+- `mindwtr-agent` - Mindwtr task management (custom, `clusters/cluster1/kubernetes/apps/ai-system/mindwtr-mcp/`).
 
-**`kind: SandboxAgent` CRs on the substrate runtime** (`apps/ai-system/kagent/substrate-agents/`, `platform: substrate`, `workerPoolRef: kagent-default`):
-- `k8s-agent` — general Kubernetes inspection/troubleshooting.
-- `observability-agent` — metrics, dashboards, alerting.
-- `promql-agent` — PromQL query generation.
-- `helm-agent` — Helm release management.
-- `cilium-manager-agent` — Cilium install/config/upgrade.
+**`kind: SandboxAgent` CRs on the substrate runtime** (`clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/`, `platform: substrate`, `workerPoolRef: kagent-default`):
+- `k8s-agent` - general Kubernetes inspection/troubleshooting.
+- `observability-agent` - metrics, dashboards, alerting.
+- `promql-agent` - PromQL query generation.
+- `helm-agent` - Helm release management.
+- `cilium-manager-agent` - Cilium install/config/upgrade.
 
-These five are `ACCEPTED=True` / `READY=True` (golden actors built; ActorTemplates in `Ready` phase, upserted into the kagent Postgres `agents` table) and are listed by the kagent REST API (`/agents`, kagent-ui) — but are **not yet invocable via the MCP server** (`list_agents` omits them; `invoke_agent` returns "not found"). See [Agent Sandbox & Code Execution](#agent-sandbox--code-execution) for the root cause and the [`.rules`](.rules) fallbacks.
+These five are `ACCEPTED=True` / `READY=True` (golden actors built; ActorTemplates in `Ready` phase, upserted into kagent Postgres `agents` table) and are listed by the kagent REST API (`/agents`, kagent-ui), but are not yet invocable via the MCP server (`list_agents` omits them; `invoke_agent` returns "not found"). See [Agent Sandbox and Code Execution](#agent-sandbox-and-code-execution) for the root cause and [`.rules`](.rules) fallbacks.
 
-**Disabled chart agents** (kagent HelmRelease toggles): `argo-rollouts-agent`, `istio-agent`, `kgateway-agent`. The 5 substrate agents and the 2 static cilium agents are also disabled in the chart so they don't double-render as classic `Agent` CRs.
+**Disabled chart agents**: `argo-rollouts-agent`, `istio-agent`, `kgateway-agent` (plus the 5 substrate agents and 2 cilium agents are disabled in the chart to prevent duplicate classic Agent CRs).
 
-The classic agents run in pod runtimes with `executeCodeBlocks: true` and isolated `sandbox` specs via the SIG-Apps `Sandbox` controller (below). Agent selection for MCP tasks is documented in [`.rules`](.rules); each agent has a specific domain and preferred use case.
+### Agent Sandbox and Code Execution
 
-### Agent Sandbox & Code Execution
+There are two sandboxing mechanisms deployed in `ai-system`:
 
-There are **two sandboxing mechanisms** deployed in `ai-system`:
+1. **SIG-Apps `Sandbox` CRD + controller** (`agents.x-k8s.io`, GitRepository ref `v1.0.0` with `controller.extensions: true`), which provides isolated, stateful single-pod runtimes for classic `kind: Agent` CRs that opt into `executeCodeBlocks`. All classic agents are configured with code execution enabled.
+2. **kagent substrate runtime (ATE / actor runtime)** - a separate control plane for sandboxed code execution via **gVisor**, used by `kind: SandboxAgent` CRs. See [Substrate Runtime](#substrate-runtime) below.
 
-1. **SIG-Apps `Sandbox` CRD + controller** (`agents.x-k8s.io`, pinned to `v0.5.0` with `controller.extensions: true`), which provides isolated, stateful single-pod runtimes for classic `kind: Agent` CRs that opt into `executeCodeBlocks` (code execution). All 5 classic agents are configured with code execution enabled.
-2. **kagent substrate runtime (ATE / actor runtime)** — a separate control plane for sandboxed code execution via **gVisor**, used by the `kind: SandboxAgent` CRs. See [Substrate Runtime](#substrate-runtime) below.
+**Two hard requirements**:
 
-**Multi-version CRD upgrade path** (SIG-Apps Sandbox): `v0.5.0` graduated the core + extension APIs from `v1alpha1` to `v1beta1` (multi-version CRDs with a self-hosted conversion webhook served by the controller on `:9443`). Because the controller is installed into `ai-system` rather than the upstream-default `agent-sandbox-system`, it rewrites each CRD's `conversion.webhook.clientConfig.service.namespace` to `ai-system` at startup (via `--webhook-namespace`). On an in-place `v0.4.6`->`v0.5.0` upgrade, the controller can deadlock during initial cache sync if pre-existing `v1alpha1` CRs must be converted before its own webhook Service has Ready endpoints — clear the (ephemeral) Sandbox/SandboxClaim/SandboxTemplate/SandboxWarmPool CRs so the first sync has nothing to convert, then let it come up clean.
-
-**Two hard requirements** (both learned the hard way):
-
-1. **Ingress from the kube-apiserver to the conversion webhook (`:9443`) must be allowed.** `ai-system` runs implicit Cilium default-deny ingress (`allow-intra-namespace` selects `endpointSelector: {}`), and the apiserver runs host-network on a *remote* control-plane node, so it isn't covered by Cilium's allow-localhost exemption. Without an explicit allow, every `v1alpha1<->v1beta1 Sandbox` conversion the apiserver issues is silently dropped: the controller crash-loops on cache-sync, `kubectl get sandboxes` hangs, and anything that creates a `Sandbox` (executeCodeBlocks Agents, or SandboxAgent reconciles) stalls to a 30s timeout. Fixed by the `allow-ingress-apiserver-to-sandbox-webhook` CiliumNetworkPolicy in `network-policies/policies/infra/ai-system.yaml` (`fromEntities: [kube-apiserver]` -> `:9443`). This rule is permanent (both for Sandbox CRD conversion on classic agents *and* for SandboxAgent use on the substrate).
-
-2. **`SandboxAgent` agents run but are not yet MCP-invocable.** The substrate `SandboxAgent` controller creates the Sandbox pod (and the kagent REST API `/agents` lists it), but the kagent **MCP** layer omits it. Root cause is an **upstream kagent limitation, not a cluster config issue** (verified live, still present on kagent 0.9.10 / `kagent-dev/kagent@main`): `MCPHandler.listReadyAgents` lists only `v1alpha2.AgentList` (it never enumerates `SandboxAgent` CRs) and hard-codes `condition.Reason == "DeploymentReady"`; classic agents report Ready with reason `DeploymentReady`, while substrate agents report `WorkloadReady`. So substrate agents are excluded twice. `invoke_agent` is blocked by the same gap (returns "agent not found or not ready"). Fix needs an upstream kagent change (also list `SandboxAgentList` and accept `WorkloadReady`); track upstream and bump kagent when fixed. Until then, use the [`.rules`](.rules) fallbacks / direct `kubectl` for the 5 substrate agents. (Historically `SandboxAgent` was tried for all 10 agents and reverted on 2026-06-27 for exactly this reason; it was re-introduced for the 5 built-ins once the substrate runtime itself was stood up — the A2A/MCP gap is the remaining blocker, not the runtime.)
-
-**Substrate namespace overrides**: upstream hard-codes the `ate-system` namespace everywhere, but this cluster runs substrate in `ai-system`. A stack of `ate-system`-vs-`ai-system` bugs gated golden-actor creation, each hidden behind the previous; all are fixed live:
-  1. `ate-controller` dial addr (`--ateapi-conn-spec`, substrate HelmRelease).
-  2. `ate-api-server` JWT key fetch (`--client-jwt-jwks-url`, on a forked image `shrinedogg/ateapi`). The JWKS URL points at the Kubernetes openid endpoint to work around Omni's IPv6 ULA issuer (`--service-account-issuer`) being unreachable from the IPv4 pod network.
-  3. `ate-api-server` atelet discovery (v0.0.9 upstreamed this via `installdefaults.NamespaceFromPodEnv()` reading the `POD_NAMESPACE` downward-API env the chart injects → resolves to `ai-system` automatically, replacing the old `ATELET_NAMESPACE` fork patch).
-  4. kagent env-source RBAC (`controller.substrate.ateApiServer.namespace=ai-system` in the kagent HelmRelease — the RoleBinding subject otherwise points at the nonexistent `ate-system` SA).
-  5. gVisor `runsc` asset (`SandboxConfig/gvisor-default` + a `runsc-cache` DaemonSet; runsc `20260622.0` staged in the rustfs `ate-snapshots` bucket and pre-cached per node, because the atelet's S3 asset client doesn't honor `AWS_ENDPOINT_URL` and would otherwise dial real AWS S3).
-  6. **Cilium egress (the real final blocker):** `ai-system` is in Cilium default-deny, and `allow-egress-internet` selected only `managed-by=kagent` pods. The atelet (`app=atelet`, Helm-managed) pulls sandbox container images in-process (`memorypullcache`, does NOT reuse node containerd) from `cr.kagent.dev` + `gcr.io`, so its pulls were policy-denied. Fixed by `allow-egress-atelet-registries` (CNP, `app=atelet` -> `world:443`). Node containerd pulls (for ordinary Deployments) always worked (host network); only the atelet's pod-network in-process pulls were blocked.
-
-**Sandbox network scoping** (classic agents): each classic agent declares allowed egress via `spec.sandbox.network.allowedDomains`:
-- Most sandboxes lock egress to `*.svc.cluster.local`, so prompt-injected code can hit in-cluster services (e.g. query VictoriaMetrics directly via `requests`/`httpx`) but can't phone out to the internet.
-- `flux-agent` is stricter still (`sandbox.network: {}` = no outbound network at all), since it's a read-only diagnostic agent whose code only needs tool-call results.
-- That allow-list is layered on the namespace's Cilium policies (`allow-egress-internet` still governs the agent pods themselves); the sandbox allow-list is the tighter boundary for *executed* code specifically.
-
-**Security & de-privileging**: The `vm-agent` runner is de-privileged (`runAsNonRoot`, drop `ALL` capabilities, `privileged: false`) because `executeCodeBlocks` writes to the container filesystem — kagent otherwise schedules agent pods privileged, which combined with tool access is too large a blast radius for a prompt-injectable LLM. **Caveat:** the other classic agents are *not* de-privileged, so kagent still schedules their pods privileged — enabling code execution there raises blast radius until they're hardened the same way vm-agent is.
+1. **Ingress from the kube-apiserver to the conversion webhook (`:9443`) must be allowed.** `ai-system` runs implicit Cilium default-deny ingress (`allow-intra-namespace` selects `endpointSelector: {}`), and the apiserver runs host-network on a remote control-plane node, so it is not covered by Cilium's allow-localhost exemption. Without an explicit allow, every Sandbox conversion the apiserver issues is silently dropped: the controller crash-loops on cache-sync, `kubectl get sandboxes` hangs, and anything creating a `Sandbox` stalls to a 30s timeout. Handled by the `allow-ingress-apiserver-to-sandbox-webhook` CiliumNetworkPolicy in `clusters/cluster1/kubernetes/apps/network-policies/policies/infra/ai-system.yaml` (`fromEntities: [kube-apiserver]` -> `:9443`).
+2. **`SandboxAgent` agents run but are not yet MCP-invocable.** Upstream kagent's `MCPHandler.listReadyAgents` lists only `v1alpha2.AgentList` and hard-codes `condition.Reason == "DeploymentReady"`; substrate agents report `WorkloadReady`. So substrate agents are excluded from `list_agents`, and `invoke_agent` returns "agent not found or not ready". Until upstream resolves this, use [`.rules`](.rules) fallbacks or direct `kubectl` for the 5 substrate agents.
 
 ### Substrate Runtime
 
-The kagent **substrate** (ATE / actor runtime) is deployed in `apps/ai-system/substrate/` (+ `substrate-crds/`) and backs the 5 `SandboxAgent` agents. Components: `ate-controller`, `ate-api-server` (Deployment `ate-api-server-deployment`, running the forked image `docker.io/shrinedogg/ateapi:v0.0.10-jwksurl`, pinned by digest), `atelet` worker DaemonSet, and `atenet-router`. A `WorkerPool` (`kagent-default`, `sandboxClass: gvisor`, `ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.10`) is created by the kagent chart. JWT issuer is the Omni KubeSpan/SideroLink ULA. All substrate Deployments are pinned to the GPU node `nv-01`. gVisor `runsc` (`20260622.0`) is staged in rustfs and pre-cached per node via the `runsc-cache` DaemonSet. The kagent chart wires it in via `controller.substrate.enabled: true`, `ateApiEndpoint: dns:///api.ai-system.svc:443`, `ateApiInsecure: true`, and `substrateWorkerPool.create: true` (`replicas: 1`).
+The kagent **substrate** (ATE / actor runtime) is deployed in `clusters/cluster1/kubernetes/apps/ai-system/substrate/` (+ `substrate-crds/`) and backs the 5 `SandboxAgent` agents.
+- **Charts**: `substrate` and `substrate-crds` at `0.0.21` (`sources/substrate-oci.yaml`, `sources/substrate-crds-oci.yaml`).
+- **Worker pool**: `kagent-default`, `sandboxClass: gvisor`, `ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.21` in kagent HelmRelease.
+- **Components**: `ate-controller`, `ate-api-server` (Deployment `ate-api-server-deployment`, running digest-pinned image `docker.io/shrinedogg/ateapi@sha256:78d90103f3054bf6544bf3726fa63800a47b970b3425a3e60f4efbfff9bbdad3` with `--client-jwt-jwks-url`), `atelet` worker DaemonSet, and `atenet-router`.
+- **Storage**: Postgres StatefulSet volumeClaimTemplate and `rustfs-data` PVC are patched to `storageClassName: host-path` via HelmRelease postRenderers.
+- **RBAC**: Manifest `clusters/cluster1/kubernetes/apps/ai-system/substrate/app/ate-system-namespace.yaml` creates the `ate-system` namespace to satisfy chart RBAC.
+- **Assets**: gVisor `runsc` (`20260622.0`) staged in rustfs and pre-cached per node via `runsc-cache` DaemonSet.
 
-**Drift correction (`driftDetection: {mode: enabled}`)**: the substrate `HelmRelease` now runs Flux's server-side dry-run drift detection on every reconcile. When chart + values are unchanged, a plain Helm upgrade no-ops, so an out-of-band change (a `kubectl delete`/`edit`) silently persists while the `HelmRelease` still reports `Ready=True` — this is exactly how the `valkey-cluster` StatefulSet stayed deleted after an out-of-band removal, leaving `ate-api-server` with no Valkey backing until the next values change forced a real upgrade. `driftDetection` makes Flux detect and revert such drift (recreating deleted resources, reverting edits back to git state) without waiting for an unrelated change, keeping the substrate stack aligned with this repo's "edit YAML in Git, never mutate the cluster" rule.
+**Drift correction (`driftDetection: {mode: enabled}`)**: the substrate `HelmRelease` runs Flux server-side dry-run drift detection on every reconcile, ensuring any out-of-band deletes or edits are reverted to git state.
 
 ### Long-Term Memory
 
-kagent is configured with vectorized memory (long-term, cross-session) backed by CNPG Postgres + pgvector, using the `embeddings` service for embedding generation. Per-agent memory is disabled on `flux-agent` (custom) because its ~64K tool schemas already push the context window toward saturation; all other classic agents (including `exa-agent`) have memory enabled. `exa-agent` additionally sets `context.compaction` at an 80K-token threshold and pairs with the 192K vLLM cap to absorb large web-search result sets without overflow — an earlier attempt to disable exa memory (suspected context overflow) was reverted once it was clear the overflow came from Exa results, not memory (the pgvector `memory` table had 0 rows). The 5 substrate agents declare no per-agent `memory:` block. None of the disabled chart agents are in scope.
+kagent is configured with vectorized memory backed by CNPG Postgres + pgvector, using the `embeddings` service for vector embeddings. Per-agent memory is disabled on `flux-agent` because its large tool schemas push context towards saturation. All other classic agents have memory enabled. `exa-agent` sets `context.compaction` at 80K tokens and pairs with the 173K vLLM cap to absorb large search results without overflow.
 
 ### MCP Servers
 
-- **Flux Operator MCP** (`flux-agent`) — read-only inspection of `FluxInstance`, sources, Kustomizations, HelmReleases, ResourceSets.
-- **VictoriaMetrics MCP** (`vm-agent`) — PromQL/MetricsQL queries, alerting rules, TSDB cardinality analysis, embedded VM docs.
-- **Exa MCP** (`exa-agent`) — Web search, code discovery, company research.
-- **codebase-memory-mcp** (`codebase-agent`) — code intelligence over indexed repos (tree-sitter → SQLite knowledge graph + bundled `nomic-embed-code` semantic search; 15 tools: `search_graph`, `trace_path`, `query_graph`, `get_architecture`, `search_code`, `detect_changes`, `manage_adr`, …). 100% local, no API keys. The upstream image ([DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) `v0.9.0`) is **stdio-only**, so the pod wraps it in an `mcp-proxy` stdio→streamable-HTTP bridge and runs git-sync as a native sidecar to keep a `main` checkout of biggs.dog at `/repo/current`. Index + watcher state persist on the `codebase-memory-data` host-path PVC. See [Agents & MCP pitfalls](#agents--mcp) for the two non-obvious constraints (musl bridge + native sidecar).
-- **Kubernetes API** (all agents) — native k8s API via controller-runtime client.
+- **Flux Operator MCP** (`flux-agent`) - read-only inspection of `FluxInstance`, sources, Kustomizations, HelmReleases, ResourceSets.
+- **VictoriaMetrics MCP** (`vm-agent`) - PromQL/MetricsQL queries, alerting rules, TSDB cardinality analysis, embedded VM docs.
+- **Exa MCP** (`exa-agent`) - Web search, code discovery, company research.
+- **codebase-memory-mcp** (`codebase-agent`) - code intelligence over indexed repos (tree-sitter -> SQLite knowledge graph + bundled semantic search; 15 tools). Wrapped in `mcp-proxy` bridge with git-sync native sidecar.
+- **mindwtr-mcp** (`mindwtr-agent`) - GTD task management against the Mindwtr SQLite database.
+- **Kubernetes API** (all agents) - native k8s API via controller-runtime client.
 
-### MCP Exposure & Routing
+### MCP Exposure and Routing
 
-The MCP endpoint is the `kagent-mcp` HTTPRoute (`https://mcp.biggs.dog/mcp`) on the internal LAN-only gateway `internal-biggs-dog` (VIP 192.168.6.15). k8s-gateway split-horizon resolves `mcp.biggs.dog` to `.6.15` for LAN/VPN clients; TLS is terminated at the gateway with the wildcard cert, no auth. WAN clients hit the public gateway (no such route -> 404). This replaced the old `kagent-mcp-lan` plain-HTTP LoadBalancer (`192.168.6.13`, pinned via `io.cilium/lb-ipam-ips`) once the agentgateway was confirmed to no longer mangle the `/mcp` Streamable-HTTP path — verified end-to-end (initialize -> notifications/initialized -> tools/list) over the route. There is no server-side request timeout — long agentic loops complete because inference is fast (~250 tok/s single-stream), not because of a route timeout.
+The MCP endpoint is the `kagent-mcp` HTTPRoute (`https://mcp.biggs.dog/mcp`) on the internal gateway `internal-biggs-dog` (VIP `192.168.6.15`). k8s-gateway split-horizon resolves `mcp.biggs.dog` to `.6.15` for LAN/VPN clients; TLS terminates at the gateway with the wildcard cert. WAN clients hitting the public gateway get a 404 (no route).
 
 ## Cluster Bootstrapping
 
-Each cluster bootstraps via its own **Flux Operator** syncing from `https://github.com/shrinedogg/biggs.dog.git` (main branch). `cluster0` syncs `clusters/cluster0` (edge/mgmt); `cluster1` syncs `clusters/cluster1` (workloads). On each, Flux reconciles:
+Each cluster bootstraps via its own **Flux Operator** syncing from `https://github.com/shrinedogg/biggs.dog.git` (main branch).
 
+- `cluster0` bootstraps via `knr-bootstrap local-talos` using `bootstrap.toml`, syncing `clusters/cluster0/capi` initially, then widening to `clusters/cluster0`.
+- `cluster1` is managed by self-hosted Omni on `cluster0` and syncs `clusters/cluster1`.
+
+On each cluster, Flux reconciles:
 1. **FluxInstance** (Flux system components).
 2. **Sources** (GitRepository, HelmRepository, OCIRepository).
 3. **Kustomizations** and **HelmReleases** (ordered via `dependsOn`).
 
-Flux pruning is currently **disabled** on both root syncs as a migration safety measure (see [Architecture](../README.md#-architecture) in the README). Secrets are decrypted by SOPS (age key) before Flux applies them.
+Flux pruning is currently disabled on both root syncs as a migration safety measure. Secrets are decrypted by SOPS (age key) before Flux applies them.
 
 ## Dependency Update Workflow
 
@@ -347,76 +328,77 @@ Renovate scans the repo for:
 - Container image tags referenced in Kubernetes manifests.
 - `renovate.json` config (grouping, scheduling, etc.).
 
-On a match, Renovate opens a PR with updated versions. CI validates the changes, and once merged, Flux reconciles automatically.
+On a match, Renovate opens a PR with updated versions. Once merged, Flux reconciles automatically.
 
-## Common Pitfalls & Lessons Learned
+## Common Pitfalls and Lessons Learned
 
 ### GPU Scaling
 
-- **Don't use JSON merge patch for zero-valued fields** — `omitempty` drops zero values, so status fields like `gamePods: 0` won't persist. Use `Status().Update()` for authoritative writes.
-- **Use the `deployments/scale` subresource** — cleaner than a full deployment patch, matches RBAC grants, and avoids null-value bugs.
-- **vLLM Deployment intentionally omits `spec.replicas`** — defaults to 1, so Flux doesn't fight the arbiter over the count.
+- **Do not use JSON merge patch for zero-valued fields** - `omitempty` drops zero values, so status fields like `gamePods: 0` will not persist. Use `Status().Update()` for authoritative writes.
+- **Use the `deployments/scale` subresource** - cleaner than a full deployment patch, matches RBAC grants, and avoids null-value bugs.
+- **vLLM Deployment intentionally omits `spec.replicas`** - defaults to 1, so Flux does not fight the arbiter over the count.
 
-### Fenrir/Games on Whales
+### Fenrir and Games on Whales
 
-- **Labels on pod templates don't survive** — Fenrir strips `metadata.labels` from the App CR templates. Live pods get labels from Fenrir's generated selectors, not the CR.
-- **Cold start latency** — image pulls + Wolf boot + agent readiness can exceed 25s, so moonlight-proxy timeout needed to be raised to 120s.
-- **Controller retries** — the direwolf-operator was stalling on reconcile retries; the fork adds automatic retries and prunes stale session entries.
+- **Labels on pod templates do not survive** - Fenrir strips `metadata.labels` from App CR templates. Live pods get labels from Fenrir's generated selectors, not the CR.
+- **Cold start latency** - image pulls + Wolf boot + agent readiness can exceed 25s, so moonlight-proxy timeout needed to be raised to 120s.
+- **Controller retries** - direwolf-operator was stalling on reconcile retries; the fork adds automatic retries and prunes stale session entries.
 
 ### Networking
 
-- **CoreDNS patching for split-horizon DNS** — hairpinning traffic out through the external gateway wastes bandwidth. Patching CoreDNS to forward `biggs.dog` queries to k8s-gateway keeps pods in-cluster.
-- **CiliumNetworkPolicy learning curve** — start with permissive policies and tighten incrementally. Two-tier (apps + infra) allows staged rollouts.
-- **Talos CoreDNS label is `coredns`, not `kube-dns`** — all `allow-egress-dns` policies initially targeted `k8s:k8s-app: kube-dns`, but Talos deploys CoreDNS with `k8s-app=coredns`. This dropped every namespace's DNS under default-deny. Fix: use `k8s-app: coredns` in policy selectors.
-- **Cilium webhook ports** — cert-manager and external-secrets webhook Services map `:443` to container port `:10250`. Cilium's kube-proxy replacement delivers traffic on the container port, so CNP ingress rules must allow `:10250`, not `:443`. Diagnosed via `cilium service list`.
-- **External-secrets cert-controller** — the cert-controller pod (`app.kubernetes.io/name=external-secrets-cert-controller`) manages ValidatingWebhookConfigurations and needs API server access. A narrow endpointSelector only matched the main controller pod, leaving the cert-controller blocked and crash-looping. Use `{}` endpointSelector to cover all external-secrets pods.
+- **CoreDNS patching for split-horizon DNS** - hairpinning traffic out through the external gateway wastes bandwidth. Patching CoreDNS to forward `biggs.dog` queries to k8s-gateway keeps pods in-cluster.
+- **CiliumNetworkPolicy learning curve** - start with permissive policies and tighten incrementally. Two-tier (apps + infra) allows staged rollouts.
+- **Talos CoreDNS label is `coredns`, not `kube-dns`** - all `allow-egress-dns` policies initially targeted `k8s:k8s-app: kube-dns`, but Talos deploys CoreDNS with `k8s-app=coredns`. This dropped every namespace's DNS under default-deny. Fix: use `k8s-app: coredns` in policy selectors.
+- **Cilium webhook ports** - cert-manager and external-secrets webhook Services map `:443` to container port `:10250`. Cilium's kube-proxy replacement delivers traffic on the container port, so CNP ingress rules must allow `:10250`, not `:443`. Diagnosed via `cilium service list`.
+- **External-secrets cert-controller** - the cert-controller pod (`app.kubernetes.io/name=external-secrets-cert-controller`) manages ValidatingWebhookConfigurations and needs API server access. A narrow endpointSelector only matched the main controller pod, leaving the cert-controller blocked and crash-looping. Use `{}` endpointSelector to cover all external-secrets pods.
+- **k8s-gateway ClusterIP pinning** - pinned to `10.101.183.97`. ClusterIP is immutable once assigned.
+- **Cross-cluster edge names resolution** - LAN clients resolving `omni.biggs.dog`, `dex.biggs.dog`, and `factory.biggs.dog` need `hosts` blocks in `k8s-gateway` and `lan-dns` pointing to `192.168.2.31`, otherwise Cloudflare's edge returns a 403 challenge page that breaks gRPC.
 
 ### Observability
 
-- **DCGM metrics lag** — free VRAM reports ~30s behind actual consumption. The `gpu-arbiter-operator` gates on vLLM down first, then VRAM as a secondary signal.
-- **Victoria Metrics cardinality** — high cardinality metrics (e.g., per-pod ephemeral metrics) can blow up storage and query times. Use recording rules and aggregation.
-- **VMSingle can't run 2 replicas on one PVC** — `vmsingle`'s local storage takes an exclusive `flock` on its data directory, so a second replica sharing the same PVC fails to start. Pinned `replicaCount: 1`, raised the memory limit to 8Gi, and set `useDefaultResources: false` so the operator stops overriding the custom resource requests/limits.
+- **DCGM metrics lag** - free VRAM reports ~30s behind actual consumption. `gpu-arbiter-operator` gates on vLLM down first, then VRAM as a secondary signal.
+- **VictoriaMetrics cardinality** - high cardinality metrics can inflate storage and query times. Use recording rules and aggregation.
+- **VMSingle cannot run 2 replicas on one PVC** - `vmsingle`'s local storage takes an exclusive `flock` on its data directory, so a second replica sharing the same PVC fails to start. Pinned `replicaCount: 1`, raised memory limit to 8Gi, and set `useDefaultResources: false`.
 
-### Media / Transcoding
+### Media and Transcoding
 
-- **Co-locate two GPU-transcode pods on one node and one starves** — Emby and Ersatz both use the Intel-iGPU `nodeSelector` (`intel.feature.node.kubernetes.io/gpu: "true"`), so with more than one Intel-GPU-capable node they could land on the same host and contend for the same iGPU. Fixed with a **preferred** (not required) `podAntiAffinity` on each toward the other's `app` label — preferred so a single remaining GPU-capable node doesn't leave one of them `Pending`.
+- **Co-locate two GPU-transcode pods on one node and one starves** - Emby and Ersatz both use the Intel-iGPU `nodeSelector` (`intel.feature.node.kubernetes.io/gpu: "true"`), so with more than one Intel-GPU-capable node they could land on the same host and contend for the same iGPU. Fixed with a preferred (not required) `podAntiAffinity` on each toward the other's `app` label.
 
 ### Storage
 
-- **Never address NVMe drives by `/dev/nvmeXn1` in anything persistent.** Enumeration order is not stable across reboots on the two-drive workers: on 2026-09-07 worker-04 came up with `nvme0n1`/`nvme1n1` swapped, Talos installed onto the Ceph OSD (osd.1 wiped; the size-3 pool kept the data), and Rook then built a 256 GB osd.4 on the OS drive it found "empty". Talos `install.diskSelector.serial`/`wwid` in the Omni template and `/dev/disk/by-id/nvme-<model>_<serial>` in the Rook `storage.nodes[].devices` list are the only safe forms. Serials come from `talosctl get disks -o yaml`.
+- **Never address NVMe drives by `/dev/nvmeXn1` in anything persistent.** Enumeration order is not stable across reboots on two-drive workers: on 2026-09-07 worker-04 came up with `nvme0n1`/`nvme1n1` swapped, Talos installed onto the Ceph OSD (osd.1 wiped; size-3 pool kept data), and Rook then built a 256 GB osd.4 on the OS drive it found empty. Talos `install.diskSelector.serial`/`wwid` in the Omni template and `/dev/disk/by-id/nvme-<model>_<serial>` in Rook `storage.nodes[].devices` list are the only safe forms. Serials come from `talosctl get disks -o yaml`.
 - **Omni cannot move Talos to a different disk on an installed machine.** Remove/re-add only re-runs the install onto the disk that already carries Talos, and `omnictl machine install` refuses machines that belong to a cluster. A real disk change needs: zap both drives from a privileged pod (`wipefs -a`, `sgdisk --zap-all`, zero the first and last 100 MB; the running system keeps its in-memory partition table), remove the machine from the template so Omni reboots it, let it boot the USB ISO into maintenance, then re-add. If Omni still does not install, its `ClusterMachineConfigStatus` holds a stale `prerebootbootid`; removing and re-adding the machine destroys that object and the clean-install path honours `diskSelector`.
 - **Restored PVCs and Flux server-side apply.** Objects recreated with `kubectl apply` are owned by `kubectl-client-side-apply`; Flux's first SSA migrates those fields and then removes anything not in git, including `spec.volumeName`, which is immutable, so the Kustomization fails with `spec is immutable after creation`. Fix: `kubectl apply --server-side --field-manager=<other> --force-conflicts` of a manifest containing only `spec.volumeName`, so a second manager owns the field and Flux leaves it alone.
-- **Rook mon-store adoption checklist.** Fresh Rook up with `mon.count: 1`, confirm new fsid and zero OSDs (prepare jobs must skip the drives as `ceph_bluestore`), stop operator + mon/mgr, replace `mon-a/data` with the captured store, keyring = the new `[mon.]` section, `monmaptool` to a single member at the mon's host IP, fsid patched into `secret/rook-ceph-mon`, `auth * required = none` via `rook-config-override` for first boot, operator back on. Re-enabling cephx needs the OLD `client.admin` key (from the captured `ceph auth ls`) to `auth import` Rook's new `mon.`/`client.admin` keys, because the adopted store still holds the old auth database.
+- **Rook mon-store adoption checklist.** Fresh Rook up with `mon.count: 1`, confirm new fsid and zero OSDs (prepare jobs must skip the drives as `ceph_bluestore`), stop operator + mon/mgr, replace `mon-a/data` with the captured store, keyring = the new `[mon.]` section, `monmaptool` to a single member at the mon's host IP, fsid patched into `secret/rook-ceph-mon`, `auth * required = none` via `rook-config-override` for first boot, operator back on. Re-enabling cephx needs the old `client.admin` key (from captured `ceph auth ls`) to `auth import` Rook's new `mon.`/`client.admin` keys, because the adopted store still holds the old auth database.
 
 ### Fresh-cluster CRD ordering
 
-Things that worked on the old cluster only because the objects already existed, all fixed in git during the 2026-09-07 rebuild:
+Things that worked on the old cluster only because objects already existed, fixed in git during the 2026-09-07 rebuild:
 
 - A `kubernetes/apps/<ns>/<app>/` directory without `kustomization.yaml` makes Flux's auto-generated root recurse into `app/`; a single unknown kind (HTTPRoute before Gateway API CRDs) then fails the whole `flux-system` Kustomization dry-run (`livekit`).
 - A CRD instance next to the HelmRelease that installs its CRD (`ClusterImageCatalog` beside the CNPG operator) fails dry-run until the operator exists; keep it in a Kustomization that `dependsOn` the operator.
-- Chart values that only "worked" because the release already existed: `zfs-localpv` `zfsNode.securityContext` is the pod-level context, `privileged` there is rejected by server-side apply on a first install.
+- Chart values that only worked because the release already existed: `zfs-localpv` `zfsNode.securityContext` is the pod-level context, `privileged` there is rejected by server-side apply on a first install.
 - Talos `inlineManifests` (the `coredns-custom` ConfigMap) apply at bootstrap only. Changing the patch later updates Omni's desired state but not the live ConfigMap; converge it once by hand with the rendered manifest.
 - Talos `install.diskSelector` in a template patch, `hosts` blocks for cross-cluster names, and the Rook CSI `Driver` CR are the other three that had lived out of band.
 
 ### Secrets
 
-- **Don't hardcode secrets** — use SOPS + age for Git-stored secrets, and External Secrets + 1Password for runtime-only secrets.
-- **Session storage** — OAuth2 Proxy's session cookie can exceed 4 KB and get chunked, breaking ext-authz subrequests. Use Dragonfly (Redis) to store the session server-side and reduce the cookie to a small ticket.
+- **Do not hardcode secrets** - use SOPS + age for Git-stored secrets, and External Secrets + 1Password for runtime-only secrets.
+- **Session storage** - OAuth2 Proxy's session cookie can exceed 4 KB and get chunked, breaking ext-authz subrequests. Use Dragonfly (Redis) to store the session server-side and reduce the cookie to a small ticket.
 
-### Agents & MCP
+### Agents and MCP
 
-- **The `SandboxAgent` MCP-listing gap is upstream, not config** — the substrate `kind: SandboxAgent` agents run, build golden actors, and are listed by the kagent REST API (`/agents`), but `MCPHandler.listReadyAgents` lists only `v1alpha2.Agent` and hard-codes `condition.Reason == "DeploymentReady"`; substrate agents report `WorkloadReady`, so they're excluded from `list_agents` and `invoke_agent` returns "not found". No Service/ingress/Helm value fixes this on kagent 0.9.10 — it needs an upstream kagent change. Verified by probing `/api/a2a/ai-system/<agent>/.well-known/agent-card.json` → "Agent not found" (registry lookup, not network).
-- **The apiserver→webhook netpol is non-obvious but critical** — Cilium's implicit default-deny dropped all apiserver traffic to the controller because the apiserver runs on a *remote* host (control-plane node). Took tracing through the CRD conversion path and the controller's deadlock during cache-sync to diagnose. This rule is now permanent (both for `SandboxAgent` use *and* for classic agents with `executeCodeBlocks`).
-- **Git history is the source of truth for restoration** — when rolling back from a partial deployment state, the backup YAML contains *generated* objects (not the source manifests). Restoring from git history (`git checkout <commit> -- <file>`) is necessary to get the canonical, working manifests. Post-migration cleanup (e.g., kustomization.yaml deletions in custom agent app dirs) don't need to be restored — Flux auto-generates kustomizations for leaf app directories. Only the source manifests and the Flux Kustomization references need recovery.
-- **A stdio-only MCP image needs a spec-strict bridge** — the codebase-memory-mcp image has no HTTP transport, so it's wrapped in a bridge. `supergateway` *appeared* to work (initialize + tools/list succeeded) but kagent's strict MCP client sends `notifications/initialized`, which supergateway rejects (406/400) → `RemoteMCPServer` stuck `Accepted=False (ReconcileFailed)`. `mcp-proxy` (official Python MCP SDK) answers 202 and registers cleanly. Verify a bridge against the *full* handshake (initialize → notifications/initialized → tools/list), not just initialize.
-- **A glibc binary can run in a musl bridge image** — codebase-memory-mcp is glibc-linked (libstdc++/libm/libz); both usable bridges (supergateway, mcp-proxy) are Alpine/musl. Solve it by copying the binary AND its glibc runtime from the upstream image into a shared emptyDir via an initContainer, then spawning through the explicit loader (`ld-linux --library-path …`). Derive the loader/libdir from `ldd` (arch-specific: `/lib64/ld-linux-x86-64.so.2` vs `/lib/ld-linux-aarch64.so.1`), never hardcode.
-- **git-sync must be a native sidecar here, not a regular container** — Kubernetes runs ALL initContainers to completion before starting ANY regular container. A regular-container git-sync never starts while a `wait-for-repo` initContainer blocks → deadlock. Run git-sync as an initContainer with `restartPolicy: Always` (native sidecar, k8s ≥1.29) ordered before the wait init.
+- **The `SandboxAgent` MCP-listing gap is upstream, not config** - substrate `kind: SandboxAgent` agents run, build golden actors, and are listed by the kagent REST API (`/agents`), but `MCPHandler.listReadyAgents` lists only `v1alpha2.Agent` and hard-codes `condition.Reason == "DeploymentReady"`; substrate agents report `WorkloadReady`, so they are excluded from `list_agents` and `invoke_agent` returns "not found". This requires an upstream kagent change.
+- **The apiserver->webhook netpol is critical** - Cilium's implicit default-deny dropped all apiserver traffic to the conversion webhook because the apiserver runs on a remote control-plane node. Fixed by explicit ingress rule (`allow-ingress-apiserver-to-sandbox-webhook`) in `clusters/cluster1/kubernetes/apps/network-policies/policies/infra/ai-system.yaml`.
+- **Git history is the source of truth for restoration** - when rolling back from partial deployment state, the backup YAML contains generated objects. Restoring from git history (`git checkout <commit> -- <file>`) recovers canonical source manifests.
+- **A stdio-only MCP image needs a spec-strict bridge** - codebase-memory-mcp is stdio-only; `supergateway` failed on `notifications/initialized`, while `mcp-proxy` answered 202 and registered cleanly with kagent.
+- **A glibc binary can run in a musl bridge image** - codebase-memory-mcp is glibc-linked; stage the binary and glibc runtime via an initContainer into shared emptyDir, then spawn through explicit loader (`ld-linux`).
+- **git-sync must be a native sidecar** - run git-sync as an initContainer with `restartPolicy: Always` (native sidecar, k8s >=1.29) ordered before the wait initContainer.
 
 ## Future Improvements
 
-- **Cilium Egress Gateway** — route outbound traffic through a dedicated node to stabilize external IPs (useful for services that block by IP).
-- **Distributed Tracing** — add Jaeger or Tempo for end-to-end tracing across kafka, game streaming, and agent operations.
-- **GPU Metrics Dashboard** — Grafana dashboard for DCGM metrics, game session lifecycle, vLLM scaling events.
-- **Finish the cluster split** — re-enable Flux pruning on both clusters once the `cluster0`/`cluster1` cutover is confirmed stable, and reconcile any remaining drift between the two trees.
-- **Substrate agents via MCP** — bump kagent once upstream lists `SandboxAgent` CRs and accepts `WorkloadReady` in `listReadyAgents`, so `k8s-agent`/`helm-agent`/`promql-agent`/`observability-agent`/`cilium-manager-agent` become MCP-invocable.
-- **Agent hardening** — de-privilege and add `securityContext` to the other classic agents (currently only vm-agent is hardened).
+- **Cilium Egress Gateway** - route outbound traffic through a dedicated node to stabilize external IPs.
+- **Distributed Tracing** - add Jaeger or Tempo for end-to-end tracing across game streaming and agent operations.
+- **GPU Metrics Dashboard** - Grafana dashboard for DCGM metrics, game session lifecycle, vLLM scaling events.
+- **Substrate agents via MCP** - bump kagent once upstream lists `SandboxAgent` CRs and accepts `WorkloadReady` in `listReadyAgents`, so substrate agents become MCP-invocable.
+- **Agent hardening** - de-privilege and add `securityContext` to remaining classic agents.


### PR DESCRIPTION
## Summary

Comprehensive documentation accuracy audit and update for `README.md` and `docs/NOTES.md` following recent architectural changes, including the `cluster0` on-prem CAPI migration and the 2026-09 `cluster1` rebuild.

## Audit Findings and Changes

| File | Drift Identified | Resolution |
| --- | --- | --- |
| `README.md` | Listed `cluster0` as UpCloud cloud VM (`87.58.147.51`) running NetBird. | Updated `cluster0` to on-prem single-node Talos management cluster (`192.168.2.31`, Talos v1.14 / K8s v1.36.0) bootstrapped via `knr-bootstrap local-talos` (`bootstrap.toml`), documenting CAPI subtree and OpenEBS storage; removed NetBird references (admin migrated to UDM VPN). |
| `README.md` | Stale `cluster1` Talos (v1.13.5) and Kubernetes (v1.36.2) versions. | Pinned to live Talos v1.13.8 and Kubernetes v1.36.3 managed via self-hosted Omni (`omni.biggs.dog`, context `self-hosted`, cluster `biggs-dog`). |
| `README.md` | Stale `nv-01` hardware notes (old motherboard / NIC specs). | Documented ASRock X870E Taichi Lite motherboard, Samsung 9100 PRO 1TB install disk, RTL8126 5GbE NIC (`enp9s0`), and Sidero kernel-signed open GPU modules (`595.71.05`). |
| `README.md` | Missing NVMe drive enumeration warnings for worker nodes. | Documented unstable NVMe `/dev` enumeration on dual-drive workers, pinning install drives via Omni `diskSelector` serials and Ceph OSDs via `/dev/disk/by-id/` paths. |
| `README.md` | Outdated `k8s-gateway` ClusterIP (`10.105.74.41`). | Updated to pinned ClusterIP `10.101.183.97` (2 replicas), documenting local hosts override for cluster0 edge names to bypass Cloudflare gRPC 403s. |
| `README.md` | Rook-Ceph missing v1.20 CSI decoupling details. | Documented Rook v1.20 (`v1.20.6`), ceph-csi-operator Driver and OperatorConfig CRs in `rook-ceph/csi-rbac/drivers.yaml`, and cluster fsid preservation. |
| `README.md` | Stale vLLM configuration (Qwen3.6-27B-PrismaSCOUT, v0.26.0, 192K context). | Updated to vLLM `v0.28.0`, model `unsloth/Qwen3.8-27B-NVFP4` (served as `qwen 3.8 - local`), 173K context ceiling (`--max-model-len=177184`), and 8-way concurrency. |
| `README.md` | Stale substrate stack versions (v0.0.10). | Updated charts to `0.0.21`, worker image `ateom-gvisor:v0.0.21`, digest-pinned `ateapi` fork, host-path storage patching, and `ate-system` namespace manifest. |
| `README.md` | Heading punctuation and emojis breaking anchor slugs. | Removed emojis and replaced slash punctuation in headings; verified all internal anchor links. |
| `docs/NOTES.md` | Intro referenced UpCloud `87.58.147.51` and NetBird. | Updated intro to on-prem `cluster0` (`192.168.2.31`) and removed NetBird. |
| `docs/NOTES.md` | Networking section referenced UpCloud LB and NetBird gRPC. | Updated to on-prem Cilium L2 announcement (`192.168.2.31/32`), `k8s-gateway` ClusterIP `10.101.183.97`, and removed NetBird gRPC notes. |
| `docs/NOTES.md` | vLLM section listed stale model, context length, and concurrency. | Documented `unsloth/Qwen3.8-27B-NVFP4`, 173K context ceiling, model right-sizing progression, and updated runtime arguments. |
| `docs/NOTES.md` | Substrate section listed v0.0.10 pins and missing storage/namespace patches. | Updated to 0.0.21, documented `host-path` storage patching for Postgres/rustfs, and `ate-system` namespace creation. |
| `docs/NOTES.md` | Contained 120+ em-dashes violating style guide. | Replaced all em-dashes with hyphens, colons, or parentheses across the entire document. |

## Verified Accurate (No Changes Needed)

- `AGENTS.md`: Already reflects current agent routing, kagent invocability status, and repository conventions.
- Dreamcast game streaming architecture: operator fork, moonlight-proxy timeout, wolf-agent udev implementation, and Sway/Gamescope handling remain accurate.
- Mindwtr architecture: three-way path split and OAuth2 Proxy forward-auth remain accurate.
- Secrets three-tier management model (SOPS, External Secrets, cert-manager).
- Observability stack architecture (VictoriaMetrics, VictoriaLogs, Grafana Operator).

## Verification

- `git diff --check`: Clean (no whitespace or syntax errors).
- Automated script verified 0 em-dashes and 0 emojis across both modified files.
- Automated script verified all internal anchor slugs and cross-file links between `README.md` and `docs/NOTES.md` resolve cleanly.
