### PR TITLE
fix(ai-system,observability): repair substrate/kagent schema drift, un-wedge VM stack

### DIFF
--- a/clusters/cluster1/flux-system/sources/substrate-crds-oci.yaml
+++ b/clusters/cluster1/flux-system/sources/substrate-crds-oci.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/kagent-dev/substrate/helm/substrate-crds
   ref:
-    tag: "0.0.26"
+    tag: "0.0.21"

--- a/clusters/cluster1/flux-system/sources/substrate-oci.yaml
+++ b/clusters/cluster1/flux-system/sources/substrate-oci.yaml
@@ -14,4 +14,4 @@ spec:
     # namespace (substrate runs in ai-system on this cluster). Renovate bumps
     # are grouped + automerge:false — see the substrate-stack rule in
     # renovate.json for the full migration checklist.
-    tag: "0.0.26"
+    tag: "0.0.21"

--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
@@ -226,8 +226,23 @@ spec:
       # feature gates — the worker CrashLoops with "atunnel: reading credential
       # bundle: ... no such file or directory". Renovate bumps for the whole
       # substrate stack are grouped + automerge:false (see renovate.json).
-      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.26
+      # PINNED to substrate 0.0.21 — the LAST version whose CRDs keep
+      # WorkerPool.spec.ateomImage and SandboxConfig.spec.default (0.0.22
+      # renamed ateomImage -> workerImage, which the kagent 0.10.1 chart
+      # does not speak; kagent is the latest that exists). MUST move in
+      # lockstep with the substrate/substrate-crds OCI source tags. The
+      # v0.0.21 tag tracks the 0.0.21 control plane; do not let Renovate
+      # split this group (renovate.json pins the whole substrate stack
+      # together, automerge:false).
+      ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.21
       template:
+        # NOTE: substrate-crds WorkerPool.spec.template is a flat pod-template
+        # fragment (nodeSelector/affinity/resources directly under `template`,
+        # NOT under template.spec). The extra `spec:` level below has been
+        # carried since 2026-07; the 0.0.21 CRD prunes it silently (fields
+        # not declared are dropped on server-side apply), which is why the
+        # live WorkerPool shows no template at all. Kept for chart-compat
+        # reasons; the nodeSelector pin is enforced by the Deployment patch.
         spec:
           nodeSelector:
             nvidia.com/gpu.present: "true"

--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/cilium-manager-agent.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/cilium-manager-agent.yaml
@@ -11,7 +11,8 @@ spec:
   description: >-
     Cilium manager agent that installs, configures, monitors, and
     troubleshoots Cilium in Kubernetes environments.
-  platform: substrate
+  # platform field removed in kagent-crds 0.10.1 (v1alpha2 SandboxAgent):
+  # the substrate settings under spec.substrate are now the only platform config.
   substrate:
     workerPoolRef:
       name: kagent-default

--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/helm-agent.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/helm-agent.yaml
@@ -11,7 +11,8 @@ spec:
   description: >-
     Helm expert AI agent specializing in using Helm for Kubernetes cluster
     management and operations.
-  platform: substrate
+  # platform field removed in kagent-crds 0.10.1 (v1alpha2 SandboxAgent):
+  # the substrate settings under spec.substrate are now the only platform config.
   substrate:
     workerPoolRef:
       name: kagent-default

--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/k8s-agent.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/k8s-agent.yaml
@@ -12,7 +12,8 @@ spec:
   description: >-
     Kubernetes expert AI agent specializing in cluster operations,
     troubleshooting, and maintenance.
-  platform: substrate
+  # platform field removed in kagent-crds 0.10.1 (v1alpha2 SandboxAgent):
+  # the substrate settings under spec.substrate are now the only platform config.
   substrate:
     workerPoolRef:
       name: kagent-default

--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/observability-agent.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/observability-agent.yaml
@@ -11,7 +11,8 @@ spec:
   description: >-
     Observability agent specialized in querying Prometheus, managing
     Grafana dashboards, and inspecting Kubernetes resources for monitoring.
-  platform: substrate
+  # platform field removed in kagent-crds 0.10.1 (v1alpha2 SandboxAgent):
+  # the substrate settings under spec.substrate are now the only platform config.
   substrate:
     workerPoolRef:
       name: kagent-default

--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/promql-agent.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/substrate-agents/promql-agent.yaml
@@ -11,7 +11,8 @@ spec:
   type: Declarative
   description: >-
     Generates PromQL queries from natural language descriptions.
-  platform: substrate
+  # platform field removed in kagent-crds 0.10.1 (v1alpha2 SandboxAgent):
+  # the substrate settings under spec.substrate are now the only platform config.
   substrate:
     workerPoolRef:
       name: kagent-default

--- a/clusters/cluster1/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -342,6 +342,10 @@ spec:
         extraArgs:
           maxLabelsPerTimeseries: "150"
         storage:
+          # No default StorageClass on this cluster (2026-09-08 rebuild):
+          # pin host-path explicitly or the PVC sits Pending forever (this
+          # exact bug wedged the 2026-09-11 reinstall).
+          storageClass: host-path
           accessModes:
             - ReadWriteOnce
           resources:


### PR DESCRIPTION
## Summary

Repairs the substrate/kagent schema drift that broke 16 Kustomizations, plus two hard blockers found along the way. Pairs with a one-off cluster-side cleanup (substrate/substrate-crds/kagent helm releases + substrate PVCs wiped for a clean reinstall).

## Root cause (verified against the shipped chart CRDs)

The 2026-09-08 Renovate group bump split two coupled stacks:

- `substrate-crds` 0.0.22 renamed `WorkerPool.spec.ateomImage` → `workerImage`; 0.0.25 removed `SandboxConfig.spec.default`
- The kagent **0.10.1** chart hardcodes `ateomImage` (bundled substrate-crds 0.0.9), so kagent 0.10.1 + substrate ≥ 0.0.22 can never apply its WorkerPool (both the upgrade *and* the rollback fail on the SSA typed-patch)
- `kagent-crds` 0.10.1 removed `SandboxAgent.spec.platform` (v1alpha2)

Last mutually-compatible combo: **kagent 0.10.1 + substrate 0.0.21** — the exact pairing the cluster ran healthy from Aug 26 until the Sep 10 reconcile of the bump.

## Changes

- `sources/substrate(-crds)-oci`: `0.0.26` → `0.0.21` (last compatible with kagent 0.10.1)
- kagent HR: `ateomImage` `v0.0.26` → `v0.0.21` (lockstep with the control plane); documents that the `substrateWorkerPool.template.spec` level is pruned by the CRD
- `substrate-agents/*` (5 manifests): drop `platform: substrate` (removed in kagent-crds 0.10.1)
- victoria-metrics HR: pin `vmsingle.storage.storageClass: host-path` (no default SC on the rebuilt cluster; the fresh 0.92.1 install's PVC sat Pending on exactly this)

## Cluster-side (already done, out-of-band and user-approved)

1. victoria-metrics: wedged `uninstalling` release secret deleted + helm-controller restarted; Flux cleanly installed 0.92.1 (KS now Ready)
2. `helm uninstall` kagent + substrate + substrate-crds; release secrets purged; substrate PVCs (`data-postgres-0`, actor memory/snapshots) wiped per user decision (clean slate)
3. Dead finalizer `kagent.dev/sandbox-agent-substrate-cleanup` removed from the 5 SandboxAgents (kagent controller was already gone); orphaned `kagent-querydoc` deploy/svc deleted

## After merge

Flux should converge: substrate-crds 0.0.26 → 0.0.21 CRD schema, substrate 0.0.21 reinstall (fresh postgres/rustfs PVCs), kagent 0.10.1 clean install, the 5 SandboxAgents reapplied without `platform`, vmsingle PVC bound on host-path. Expected green: kagent, substrate, substrate-crds, kagent-substrate-agents + the 7 dependents (cilium-agents, codebase-memory-mcp, embeddings, exa-mcp, flux-mcp, mindwtr-mcp, victoria-metrics-mcp).

## Not in this PR (tracked separately)

- cnpg-pocket-id / cnpg-renovate rehome off control-01 (switchover + PVC re-provision — Root 2)
