### PR TITLE
fix(kagent): flatten substrateWorkerPool.template values

### DIFF
--- a/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/ai-system/kagent/app/helmrelease.yaml
@@ -236,13 +236,10 @@ spec:
       # together, automerge:false).
       ateomImage: ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.21
       template:
-        # NOTE: substrate-crds WorkerPool.spec.template is a flat pod-template
-        # fragment (nodeSelector/affinity/resources directly under `template`,
-        # NOT under template.spec). The extra `spec:` level below has been
-        # carried since 2026-07; the 0.0.21 CRD prunes it silently (fields
-        # not declared are dropped on server-side apply), which is why the
-        # live WorkerPool shows no template at all. Kept for chart-compat
-        # reasons; the nodeSelector pin is enforced by the Deployment patch.
-        spec:
-          nodeSelector:
-            nvidia.com/gpu.present: "true"
+        # Flat pod-template fragment (the chart pipes this verbatim into
+        # WorkerPool.spec.template): nodeSelector sits DIRECTLY under
+        # `template`, not under template.spec — the CRD has no `spec` level
+        # here and the SSA typed-patch rejects it (".spec.template.spec:
+        # field not declared in schema", which broke the 0.10.1 install).
+        nodeSelector:
+          nvidia.com/gpu.present: "true"


### PR DESCRIPTION
## Summary

Follow-up to #485. The kagent chart pipes `.Values.substrateWorkerPool.template` verbatim into `WorkerPool.spec.template`, which is a **flat** pod-template fragment in the substrate-crds schema. The extra `spec:` nesting (carried since 2026-07) is rejected by the SSA typed-patch:

```
.spec.template.spec: field not declared in schema
```

This is the error that broke the kagent 0.10.1 install after the clean reinstall (visible on the HelmRelease after #485 merged). `nodeSelector` now sits directly under `template`.

## Verification

- kagent 0.10.1 template: `{{- toYaml .Values.substrateWorkerPool.template | nindent 4 }}` under `spec.template` — verbatim passthrough
- substrate-crds 0.0.21 `WorkerPool.spec.template` schema: `annotations, labels, nodeAffinity, nodeSelector, priorityClassName, resources, tolerations` — no `spec`
