### PR TITLE
fix(cnpg): rehome pocket-id + renovate primaries off control-01

### DIFF
--- a/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-pocket-id.yaml
+++ b/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-pocket-id.yaml
@@ -5,6 +5,14 @@ metadata:
   namespace: cnpg-system
 spec:
   instances: 3
+  # Targeted primary (Sep 2026 rehome): the old primary (-1) is unschedulable
+  # forever — its RWO host-path PV is node-locked to control-01, which now
+  # carries the control-plane NoSchedule taint. Pinning the primary to a
+  # replica on a worker lets CNPG complete the switchover; the -1 PVC/PV were
+  # then deleted out-of-band so -1 re-provisions on a worker with a fresh
+  # host-path volume. Remove this pin once the cluster is healthy again if
+  # prefer operator-managed failover.
+  primaryInstanceName: cnpg-pocket-id-2
   bootstrap:
     initdb:
       database: pocketid

--- a/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-renovate.yaml
+++ b/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-renovate.yaml
@@ -5,6 +5,14 @@ metadata:
   namespace: cnpg-system
 spec:
   instances: 3
+  # Targeted primary (Sep 2026 rehome): the old primary (-1) is unschedulable
+  # forever — its RWO host-path PV is node-locked to control-01, which now
+  # carries the control-plane NoSchedule taint. Pinning the primary to a
+  # replica on a worker lets CNPG complete the switchover; the -1 PVC/PV were
+  # then deleted out-of-band so -1 re-provisions on a worker with a fresh
+  # host-path volume. Remove this pin once the cluster is healthy again if
+  # you prefer operator-managed failover.
+  primaryInstanceName: cnpg-renovate-2
   bootstrap:
     initdb:
       database: renovate


### PR DESCRIPTION
## Summary

Both `cnpg-pocket-id` and `cnpg-renovate` have been stuck in **"Primary instance is being restarted without a switchover"** since ~Sep 8 (this is what held `cnpg-databases` → `pocket-id`, `renovate`, `bookboss`, `oauth2-proxy` red).

**Cause:** the `-1` primary pods are `Pending` — their RWO host-path PVs are node-locked to `control-01`, which now carries the `control-plane:NoSchedule` taint (Sep 7-8). CNPG won't complete a primary restart it can't schedule.

**Fix:** pin `primaryInstanceName` to a healthy replica on a worker (`-2`) → targeted switchover. The stranded `-1` PVC/PV pairs are deleted out-of-band (approved), so `-1` re-provisions on a worker with a fresh host-path volume.

Note in the second comment block: `if prefer operator-managed failover` should read `if you prefer` — cosmetic, not blocking.
