### PR TITLE
Revert "fix(cnpg): rehome pocket-id + renovate primaries off control-01"

### DIFF
--- a/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-pocket-id.yaml
+++ b/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-pocket-id.yaml
@@ -5,14 +5,6 @@ metadata:
   namespace: cnpg-system
 spec:
   instances: 3
-  # Targeted primary (Sep 2026 rehome): the old primary (-1) is unschedulable
-  # forever — its RWO host-path PV is node-locked to control-01, which now
-  # carries the control-plane NoSchedule taint. Pinning the primary to a
-  # replica on a worker lets CNPG complete the switchover; the -1 PVC/PV were
-  # then deleted out-of-band so -1 re-provisions on a worker with a fresh
-  # host-path volume. Remove this pin once the cluster is healthy again if
-  # prefer operator-managed failover.
-  primaryInstanceName: cnpg-pocket-id-2
   bootstrap:
     initdb:
       database: pocketid

--- a/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-renovate.yaml
+++ b/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-renovate.yaml
@@ -5,14 +5,6 @@ metadata:
   namespace: cnpg-system
 spec:
   instances: 3
-  # Targeted primary (Sep 2026 rehome): the old primary (-1) is unschedulable
-  # forever — its RWO host-path PV is node-locked to control-01, which now
-  # carries the control-plane NoSchedule taint. Pinning the primary to a
-  # replica on a worker lets CNPG complete the switchover; the -1 PVC/PV were
-  # then deleted out-of-band so -1 re-provisions on a worker with a fresh
-  # host-path volume. Remove this pin once the cluster is healthy again if
-  # you prefer operator-managed failover.
-  primaryInstanceName: cnpg-renovate-2
   bootstrap:
     initdb:
       database: renovate


### PR DESCRIPTION
Reverts #487: CNPG 1.30 removed `spec.primaryInstanceName` from the Cluster CRD, so the field is rejected by SSA and `cnpg-databases` fails reconciliation. The rehome is instead performed the supported way (out-of-band): patching `status.targetPrimary` (the `kubectl cnpg promote` mechanism) + deleting the stranded `-1` PVC/PV pair.
