### PR TITLE
fix(cnpg): tolerate control-plane taint on pocket-id so -1 can serve as primary

### DIFF
--- a/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-pocket-id.yaml
+++ b/clusters/cluster1/kubernetes/apps/cnpg/cnpg/databases/cnpg-pocket-id.yaml
@@ -5,6 +5,19 @@ metadata:
   namespace: cnpg-system
 spec:
   instances: 3
+  # The Sep 2026 rebuild created this cluster with instance -1's host-path PV
+  # node-locked to control-01, which carries the control-plane NoSchedule
+  # taint. -1 holds the ONLY copy of the current database incarnation (the
+  # barman WAL archive was polluted by the pre-rebuild system id during the
+  # rebuild, so replicas -2/-3 cannot complete archive recovery). Tolerate
+  # the taint so -1 can run as primary on control-01 until the replicas are
+  # re-cloned from it and a proper switchover can move the primary off.
+  affinity:
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+        effect: NoSchedule
   bootstrap:
     initdb:
       database: pocketid


### PR DESCRIPTION
## Why

`cnpg-pocket-id` is stuck in `InplaceDeletePrimaryRestart`: the operator waits for the `-1` primary to come back, but `-1` is `Pending` — its RWO host-path PV is node-locked to `control-01` (carries `control-plane:NoSchedule` since the Sep 7-8 rebuild).

New finding while executing the switchover plan: the barman WAL archive was **polluted with the pre-rebuild system identifier** during the Sep 8 re-initdb, so replicas `-2`/`-3` cannot complete archive recovery (`WAL file is from different database system`). `-1` holds the only copy of the current incarnation.

## What

Add a `control-plane:NoSchedule` toleration so `-1` schedules on control-01, completes the primary restart, and lets CNPG re-clone `-2`/`-3` from it. After the cluster is healthy, do a proper switchover and remove this toleration (the PV is still on control-01; a full rehome of `-1` is a follow-up once replicas are re-cloned).

Note: `cnpg-renovate` recovered with a status-patch switchover (promoted `-2`, accepting writes); its stranded `-1` PVC/PV was deleted so it re-provisions on a worker. The initial `spec.primaryInstanceName` approach (#487) was reverted in #488 — CNPG 1.30 removed that field.
