### PR TITLE
fix(observability): vmsingle storage key is storageClassName, not storageClass

### DIFF
--- a/clusters/cluster1/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/clusters/cluster1/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -344,8 +344,10 @@ spec:
         storage:
           # No default StorageClass on this cluster (2026-09-08 rebuild):
           # pin host-path explicitly or the PVC sits Pending forever (this
-          # exact bug wedged the 2026-09-11 reinstall).
-          storageClass: host-path
+          # exact bug wedged the 2026-09-11 reinstall). NOTE the key is
+          # storageClassName (the VMSingle CRD embeds a PVC-spec-shaped
+          # storage object); `storageClass` is rejected by SSA.
+          storageClassName: host-path
           accessModes:
             - ReadWriteOnce
           resources:


### PR DESCRIPTION
Follow-up to #485: the VMSingle CRD's storage object is PVC-spec-shaped, so the correct key is `storageClassName`. `storageClass` fails SSA and looped the upgrade into rollbacks, keeping the vmsingle PVC Pending.